### PR TITLE
Introduce Low fod map diet

### DIFF
--- a/.github/chatmodes/recipe_maker.chatmode.md
+++ b/.github/chatmodes/recipe_maker.chatmode.md
@@ -1,8 +1,8 @@
 ---
 description: 'Twoją rolą jest konwertowanie przepisów z innych formatów do formatu docelowego. Skorzystaj z podanego przykładu jako wzoru.'
-tools: ['codebase', 'fetch', 'search', 'searchResults', 'azure-mcp-server-ext']
+tools: ['codebase', 'fetch', 'search', 'searchResults']
 ---
-Twoją rolą jest konwertowanie przepisów z innych formatów do formatu docelowego. Stwórz nowy plik w folderze content. Skorzystaj z podanego przykładu jako wzoru:
+Twoją rolą jest konwertowanie przepisów z innych formatów do formatu docelowego. Stwórz nowy plik w folderze content. Uzupełnij tabelę wartości odżywczych oraz szczegóły na temat dopasowania do diety low fodmap. Skorzystaj z podanego przykładu jako wzoru:
 ---
 draft: false  
 title: "Pieczony Kurczak z Ryżem, Warzywami i Fit Sosem Serowym"  
@@ -20,7 +20,12 @@ calories: 164
 protein: 13
 fat: 6
 carbohydrate: 14 
-link: https://www.youtube.com/watch?v=AIlwvEvCONM  
+link: https://www.youtube.com/watch?v=AIlwvEvCONM
+fodmap:
+  status: "yes"
+  serving_ok: "OK w tej porcji"
+  notes: "Kurczak, suszone pomidory, majonez, wafle ryżowe - wszystko bezpieczne"
+  substitutions: []
 ---
 
 ## Składniki

--- a/content/Chilli con carne.md
+++ b/content/Chilli con carne.md
@@ -15,6 +15,15 @@ calories: 332
 protein: 25
 fat: 15
 carbohydrate: 31
+diets: ["low-fodmap"]
+fodmap:
+  status: "no"
+  serving_ok: "Unikaj na diecie Low FODMAP"
+  notes: "Cebula i czosnek to główne źródła fruktatów. Fasola też może być problematyczna."
+  substitutions:
+    - "cebula -> zielona część dymki lub olej cebulowy"
+    - "czosnek -> olej czosnkowy"
+    - "czerwona fasola -> marchewka w większej ilości lub batatach"
 ---
 
 ## Składniki

--- a/content/Chilli con carne.md
+++ b/content/Chilli con carne.md
@@ -19,11 +19,11 @@ carbohydrate: 31
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"
-  notes: "Cebula i czosnek to główne źródła fruktatów. Fasola też może być problematyczna."
+  notes: "Cebula i czosnek to główne źródła fruktanów. Czerwona fasola również jest wysokofodmapowa (zwłaszcza w dużej porcji)."
   substitutions:
-    - "cebula -> zielona część dymki lub olej cebulowy"
+    - "cebula -> zielona część dymki/szczypior"
     - "czosnek -> olej czosnkowy"
-    - "czerwona fasola -> marchewka w większej ilości lub batatach"
+    - "czerwona fasola -> więcej marchewki lub bataty"
 ---
 
 ## Składniki

--- a/content/Chilli con carne.md
+++ b/content/Chilli con carne.md
@@ -15,7 +15,7 @@ calories: 332
 protein: 25
 fat: 15
 carbohydrate: 31
-diets: ["low-fodmap"]
+
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"

--- a/content/Ciastka owsiane.md
+++ b/content/Ciastka owsiane.md
@@ -16,6 +16,14 @@ protein: 7
 fat: 5
 carbohydrate: 38
 link: https://www.youtube.com/shorts/x1zHo9TF1NA
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "1-2 ciasteczka na porcję (maksymalnie 1/3 banana na porcję)"
+  notes: "Banany są OK w małych ilościach. Płatki owsiane - umiarkowanie."
+  substitutions:
+    - "2 banany -> 1 banan + 60g jabłek lub 30g daktyli"
+    - "100g płatków owsianych -> 60g płatków owsianych + 40g mąki ryżowej"
 ---
 
 ## Składniki

--- a/content/Ciastka owsiane.md
+++ b/content/Ciastka owsiane.md
@@ -19,11 +19,11 @@ link: https://www.youtube.com/shorts/x1zHo9TF1NA
 
 fodmap:
   status: "depends"
-  serving_ok: "1-2 ciasteczka na porcję (maksymalnie 1/3 banana na porcję)"
-  notes: "Banany są OK w małych ilościach. Płatki owsiane - umiarkowanie."
+  serving_ok: "1–2 ciasteczka; łączny banan ≤ 1/2 szt. na porcję; podawać bez dodatku miodu"
+  notes: "Dojrzały banan w większej ilości jest wysokofodmapowy. Płatki owsiane są OK w umiarkowanej porcji. Unikaj daktyli (wysoko FODMAP)."
   substitutions:
-    - "2 banany -> 1 banan + 60g jabłek lub 30g daktyli"
-    - "100g płatków owsianych -> 60g płatków owsianych + 40g mąki ryżowej"
+    - "2 banany -> 1 banan + 60 g puree jabłkowego (bez dosładzania)"
+    - "część płatków -> mąka ryżowa/gluten-free owsiana, by zmniejszyć porcję owsa"
 ---
 
 ## Składniki

--- a/content/Ciastka owsiane.md
+++ b/content/Ciastka owsiane.md
@@ -16,7 +16,7 @@ protein: 7
 fat: 5
 carbohydrate: 38
 link: https://www.youtube.com/shorts/x1zHo9TF1NA
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "1-2 ciasteczka na porcję (maksymalnie 1/3 banana na porcję)"

--- a/content/Gofry Twarogowe.md
+++ b/content/Gofry Twarogowe.md
@@ -19,12 +19,12 @@ carbohydrate: 18
 
 fodmap:
   status: "depends"
-  serving_ok: "1 gofr na porcję (maksymalnie 1/4 banana na porcję)"
-  notes: "Banan w małych ilościach jest OK. Mąka może być problematyczna."
+  serving_ok: "OK po modyfikacjach: twaróg i mleko bez laktozy; mąka bez pszenicy; banan ≤ 1/3 szt. na porcję"
+  notes: "Twaróg i mleko zawierają laktozę – wybierz wersje bez laktozy. Mąka pszenna to źródło fruktanów – zamień na ryżową/owsianą (GF). Dojrzały banan w większej porcji zwiększa FODMAP."
   substitutions:
-    - "mąka pszenna -> mąka ryżowa lub owsiana"
-    - "1 banan -> 1/2 banana + więcej twarogu"
-    - "mleko -> mleko bezlaktozowe"
+    - "mąka pszenna -> mąka ryżowa/gluten-free owsiana"
+    - "twaróg/mleko -> odpowiedniki bez laktozy"
+    - "banan -> mniejsza ilość (≤ 1/3 szt. na porcję) lub bardziej niedojrzały"
 ---
 
 ## Składniki

--- a/content/Gofry Twarogowe.md
+++ b/content/Gofry Twarogowe.md
@@ -16,7 +16,7 @@ calories: 158
 protein: 10
 fat: 5
 carbohydrate: 18
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "1 gofr na porcję (maksymalnie 1/4 banana na porcję)"

--- a/content/Gofry Twarogowe.md
+++ b/content/Gofry Twarogowe.md
@@ -16,6 +16,15 @@ calories: 158
 protein: 10
 fat: 5
 carbohydrate: 18
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "1 gofr na porcję (maksymalnie 1/4 banana na porcję)"
+  notes: "Banan w małych ilościach jest OK. Mąka może być problematyczna."
+  substitutions:
+    - "mąka pszenna -> mąka ryżowa lub owsiana"
+    - "1 banan -> 1/2 banana + więcej twarogu"
+    - "mleko -> mleko bezlaktozowe"
 ---
 
 ## Składniki

--- a/content/Gulasz Z Łopatki Wieprzowej.md
+++ b/content/Gulasz Z Łopatki Wieprzowej.md
@@ -15,6 +15,15 @@ calories: 133
 protein: 11
 fat: 8
 carbohydrate: 4
+diets: ["low-fodmap"]
+fodmap:
+  status: "no"
+  serving_ok: "Unikaj na diecie Low FODMAP"
+  notes: "Cebula i czosnek to główne problemy w tym przepisie."
+  substitutions:
+    - "cebula -> zielona część dymki"
+    - "czosnek -> olej czosnkowy"
+    - "duża ilość cebuli -> więcej marchewki i papryki"
 ---
 
 ## Składniki

--- a/content/Gulasz Z Łopatki Wieprzowej.md
+++ b/content/Gulasz Z Łopatki Wieprzowej.md
@@ -15,7 +15,7 @@ calories: 133
 protein: 11
 fat: 8
 carbohydrate: 4
-diets: ["low-fodmap"]
+
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"

--- a/content/Gulasz Z Łopatki Wieprzowej.md
+++ b/content/Gulasz Z Łopatki Wieprzowej.md
@@ -19,11 +19,11 @@ carbohydrate: 4
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"
-  notes: "Cebula i czosnek to główne problemy w tym przepisie."
+  notes: "Cebula i czosnek (fruktany) czynią danie nieodpowiednim."
   substitutions:
-    - "cebula -> zielona część dymki"
+    - "cebula -> zielona część dymki/szczypior"
     - "czosnek -> olej czosnkowy"
-    - "duża ilość cebuli -> więcej marchewki i papryki"
+    - "aromat -> asafetyda/papryka wędzona + więcej marchewki i papryki"
 ---
 
 ## Składniki

--- a/content/Jajecznica Z Szpinakiem.md
+++ b/content/Jajecznica Z Szpinakiem.md
@@ -16,7 +16,7 @@ calories: 144
 protein: 10
 fat: 10
 carbohydrate: 2
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Bez dodatków z cebulą; pomidorki maksymalnie 5 sztuk"

--- a/content/Jajecznica Z Szpinakiem.md
+++ b/content/Jajecznica Z Szpinakiem.md
@@ -16,6 +16,15 @@ calories: 144
 protein: 10
 fat: 10
 carbohydrate: 2
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Bez dodatków z cebulą; pomidorki maksymalnie 5 sztuk"
+  notes: "Szpinak i jajka są OK. Unikaj czosnku i cebuli w dodatkach."
+  substitutions:
+    - "czosnek -> olej czosnkowy lub pominąć"
+    - "cebula w dodatkach -> szczypiorek"
+    - "chleb pszenny -> chleb bezglutenowy"
 ---
 
 ## Składniki

--- a/content/Jajecznica Z Szpinakiem.md
+++ b/content/Jajecznica Z Szpinakiem.md
@@ -19,12 +19,13 @@ carbohydrate: 2
 
 fodmap:
   status: "depends"
-  serving_ok: "Bez dodatków z cebulą; pomidorki maksymalnie 5 sztuk"
-  notes: "Szpinak i jajka są OK. Unikaj czosnku i cebuli w dodatkach."
+  serving_ok: "OK po modyfikacjach: bez czosnku; pieczywo bez pszenicy; awokado ≤ 30 g; pomidorki ≤ 5 szt."
+  notes: "Czosnek (fruktany) niewskazany – użyj oleju czosnkowego. Pieczywo pszenne zawiera fruktany – wybierz bezglutenowe. Awokado tylko w małej porcji. Szpinak i jajka są bezpieczne."
   substitutions:
     - "czosnek -> olej czosnkowy lub pominąć"
-    - "cebula w dodatkach -> szczypiorek"
-    - "chleb pszenny -> chleb bezglutenowy"
+    - "cebula w dodatkach -> szczypiorek/ziele dymki"
+    - "chleb pszenny -> pieczywo bezglutenowe"
+    - "awokado (do podania) -> ≤ 30 g lub pominąć"
 ---
 
 ## Składniki

--- a/content/Jajecznica.md
+++ b/content/Jajecznica.md
@@ -16,6 +16,12 @@ calories: 196
 protein: 11
 fat: 16
 carbohydrate: 1
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "Porcja bez ograniczeń"
+  notes: "Wszystkie składniki są bezpieczne na diecie Low FODMAP."
+  substitutions: []
 ---
 
 ## Składniki

--- a/content/Jajecznica.md
+++ b/content/Jajecznica.md
@@ -16,7 +16,7 @@ calories: 196
 protein: 11
 fat: 16
 carbohydrate: 1
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "Porcja bez ograniczeń"

--- a/content/Jajka zapiekane Z Szynką I Warzywami_z szynką i warzywami.md
+++ b/content/Jajka zapiekane Z Szynką I Warzywami_z szynką i warzywami.md
@@ -16,6 +16,14 @@ calories: 196
 protein: 15
 fat: 12
 carbohydrate: 6
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Brokuły - maksymalnie 75g na porcję, cebula - maksymalnie 2 łyżki"
+  notes: "Brokuły w małych ilościach są OK. Uważaj na ilość cebuli."
+  substitutions:
+    - "cebula -> zielona część dymki"
+    - "duże ilości brokułów -> więcej papryki"
 ---
 
 ## Składniki

--- a/content/Jajka zapiekane Z Szynką I Warzywami_z szynką i warzywami.md
+++ b/content/Jajka zapiekane Z Szynką I Warzywami_z szynką i warzywami.md
@@ -16,7 +16,7 @@ calories: 196
 protein: 15
 fat: 12
 carbohydrate: 6
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Brokuły - maksymalnie 75g na porcję, cebula - maksymalnie 2 łyżki"

--- a/content/Jajka zapiekane Z Szynką I Warzywami_z szynką i warzywami.md
+++ b/content/Jajka zapiekane Z Szynką I Warzywami_z szynką i warzywami.md
@@ -19,10 +19,10 @@ carbohydrate: 6
 
 fodmap:
   status: "depends"
-  serving_ok: "Brokuły - maksymalnie 75g na porcję, cebula - maksymalnie 2 łyżki"
-  notes: "Brokuły w małych ilościach są OK. Uważaj na ilość cebuli."
+  serving_ok: "OK po modyfikacjach: bez cebuli; brokuły (różyczki) ~60–75 g/porcję"
+  notes: "Cebula (fruktany) niewskazana. Brokuły – wybieraj różyczki i trzymaj umiarkowaną porcję. Szynka zwykle OK – sprawdź dodatki (bez cebuli/czosnku)."
   substitutions:
-    - "cebula -> zielona część dymki"
+    - "cebula -> zielona część dymki/szczypior"
     - "duże ilości brokułów -> więcej papryki"
 ---
 

--- a/content/Kotleciki a la pożarskie.md
+++ b/content/Kotleciki a la pożarskie.md
@@ -15,6 +15,14 @@ calories: 150
 protein: 22
 fat: 3
 carbohydrate: 7
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Por - tylko zielona część; marchewka bez ograniczeń"
+  notes: "Por może być problematyczny - używaj tylko zielonej części."
+  substitutions:
+    - "biała część pora -> zielona część pora"
+    - "mąka pszenna -> mąka jaglana (jak w przepisie) lub ryżowa"
 ---
 
 ## Składniki

--- a/content/Kotleciki a la pożarskie.md
+++ b/content/Kotleciki a la pożarskie.md
@@ -19,10 +19,11 @@ carbohydrate: 7
 fodmap:
   status: "depends"
   serving_ok: "Por - tylko zielona część; marchewka bez ograniczeń"
-  notes: "Por może być problematyczny - używaj tylko zielonej części."
+  notes: "Por – tylko zielona część. Unikaj czosnku i mieszanek przypraw z cebulą/czosnkiem."
   substitutions:
     - "biała część pora -> zielona część pora"
     - "mąka pszenna -> mąka jaglana (jak w przepisie) lub ryżowa"
+    - "czosnek granulowany -> asafetyda lub olej czosnkowy"
 ---
 
 ## Składniki

--- a/content/Kotleciki a la pożarskie.md
+++ b/content/Kotleciki a la pożarskie.md
@@ -15,7 +15,7 @@ calories: 150
 protein: 22
 fat: 3
 carbohydrate: 7
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Por - tylko zielona część; marchewka bez ograniczeń"

--- a/content/Kurczak Z Szpinakiem I Mascarpone.md
+++ b/content/Kurczak Z Szpinakiem I Mascarpone.md
@@ -15,7 +15,7 @@ calories: 433
 protein: 39
 fat: 27
 carbohydrate: 6
-diets: ["low-fodmap"]
+
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"

--- a/content/Kurczak Z Szpinakiem I Mascarpone.md
+++ b/content/Kurczak Z Szpinakiem I Mascarpone.md
@@ -15,6 +15,14 @@ calories: 433
 protein: 39
 fat: 27
 carbohydrate: 6
+diets: ["low-fodmap"]
+fodmap:
+  status: "no"
+  serving_ok: "Unikaj na diecie Low FODMAP"
+  notes: "Cebula i czosnek to główne problemy w tym przepisie."
+  substitutions:
+    - "cebula -> zielona część dymki"
+    - "czosnek -> olej czosnkowy"
 ---
 
 ## Składniki

--- a/content/Kurczak Z Szpinakiem I Mascarpone.md
+++ b/content/Kurczak Z Szpinakiem I Mascarpone.md
@@ -17,12 +17,13 @@ fat: 27
 carbohydrate: 6
 
 fodmap:
-  status: "no"
-  serving_ok: "Unikaj na diecie Low FODMAP"
-  notes: "Cebula i czosnek to główne problemy w tym przepisie."
-  substitutions:
-    - "cebula -> zielona część dymki"
-    - "czosnek -> olej czosnkowy"
+   status: "no"
+   serving_ok: "W obecnej formie nieodpowiednie (cebula, czosnek, mascarpone)"
+   notes: "Cebula/czosnek (fruktany) i mascarpone (wysoka laktoza) czynią danie niezgodne na etapie eliminacji."
+   substitutions:
+      - "cebula -> zielona część dymki/szczypior"
+      - "czosnek -> olej czosnkowy (bez cząstek)"
+      - "mascarpone -> śmietanka/napój bez laktozy + tarty ser dojrzewający (w małej porcji)"
 ---
 
 ## Składniki

--- a/content/Kurczak w Panierce Parmezanowo-Panko z Batatami i Błyskawiczną Sałatką.md
+++ b/content/Kurczak w Panierce Parmezanowo-Panko z Batatami i Błyskawiczną Sałatką.md
@@ -16,6 +16,14 @@ protein: 15
 fat: 6
 carbohydrate: 13
 link: https://youtu.be/SQ4saBQrBYc?t=224
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Panierka może zawierać gluten - sprawdź skład"
+  notes: "Bataty i kurczak są OK. Problem może być w panierce panko."
+  substitutions:
+    - "panierka panko -> bezglutenowa panierka lub mielone orzechy"
+    - "mąka pszenna -> mąka ryżowa (jeśli w przepisie)"
 ---
 
 ## Składniki

--- a/content/Kurczak w Panierce Parmezanowo-Panko z Batatami i Błyskawiczną Sałatką.md
+++ b/content/Kurczak w Panierce Parmezanowo-Panko z Batatami i Błyskawiczną Sałatką.md
@@ -16,7 +16,7 @@ protein: 15
 fat: 6
 carbohydrate: 13
 link: https://youtu.be/SQ4saBQrBYc?t=224
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Panierka może zawierać gluten - sprawdź skład"

--- a/content/Kurczak w Panierce Parmezanowo-Panko z Batatami i Błyskawiczną Sałatką.md
+++ b/content/Kurczak w Panierce Parmezanowo-Panko z Batatami i Błyskawiczną Sałatką.md
@@ -19,11 +19,11 @@ link: https://youtu.be/SQ4saBQrBYc?t=224
 
 fodmap:
   status: "depends"
-  serving_ok: "Panierka może zawierać gluten - sprawdź skład"
-  notes: "Bataty i kurczak są OK. Problem może być w panierce panko."
+  serving_ok: "OK po modyfikacjach: panierka bez pszenicy; sałatka bez czerwonej cebuli"
+  notes: "Panko zwykle pszenne (fruktany) – wybierz wersję bezglutenową/ryżową. Czerwona cebula w sałatce jest wysokofodmapowa – zamień na szczypior. Bataty są OK w umiarkowanej porcji."
   substitutions:
-    - "panierka panko -> bezglutenowa panierka lub mielone orzechy"
-    - "mąka pszenna -> mąka ryżowa (jeśli w przepisie)"
+    - "panko pszenne -> bułka tarta bezglutenowa/ryżowa lub drobno mielone płatki kukurydziane"
+    - "czerwona cebula -> zielona część dymki/szczypior"
 ---
 
 ## Składniki

--- a/content/Losos Pieczony Z Ziemniakami I Sosem Szparagowym.md
+++ b/content/Losos Pieczony Z Ziemniakami I Sosem Szparagowym.md
@@ -18,11 +18,12 @@ carbohydrate: 10
 
 fodmap:
   status: "depends"
-  serving_ok: "Szparagi - maksymalnie 5 łodyg na porcję; ziemniaki bez ograniczeń"
-  notes: "Unikaj czosnku. Szparagi w większych ilościach zawierają fruktany."
+  serving_ok: "OK po modyfikacjach: bez czosnku; mascarpone zamienić; suszone pomidory ≤ 8–12 g/os.; szparagi 4–5 łodyg"
+  notes: "Czosnek (fruktany) i mascarpone (laktoza) są problematyczne. Suszone pomidory podnoszą FODMAP powyżej małej porcji – ogranicz. Ziemniaki i łosoś są bezpieczne."
   substitutions:
-    - "czosnek świeży -> olej czosnkowy"
-    - "czosnek granulowany -> imbir w proszku lub kurkuma"
+    - "czosnek -> olej czosnkowy (bez cząstek)"
+    - "mascarpone -> śmietanka/śmietana bez laktozy lub tarty ser dojrzewający (mała porcja)"
+    - "suszone pomidory -> ≤ 8–12 g/os. lub świeże pomidory w małej ilości"
 ---
 
 Oto przepis na pieczonego łososia w piekarniku z ziemniakami pieczonymi oraz kremowym sosem z szparagów, mascarpone i suszonych pomidorów. Przepis jest łatwy do wykonania i pozwoli uzyskać efektowny obiad z wyrazistym smakiem.

--- a/content/Losos Pieczony Z Ziemniakami I Sosem Szparagowym.md
+++ b/content/Losos Pieczony Z Ziemniakami I Sosem Szparagowym.md
@@ -15,7 +15,7 @@ calories: 193
 protein: 14
 fat: 10
 carbohydrate: 10
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Szparagi - maksymalnie 5 łodyg na porcję; ziemniaki bez ograniczeń"

--- a/content/Losos Pieczony Z Ziemniakami I Sosem Szparagowym.md
+++ b/content/Losos Pieczony Z Ziemniakami I Sosem Szparagowym.md
@@ -15,6 +15,14 @@ calories: 193
 protein: 14
 fat: 10
 carbohydrate: 10
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Szparagi - maksymalnie 5 łodyg na porcję; ziemniaki bez ograniczeń"
+  notes: "Unikaj czosnku. Szparagi w większych ilościach zawierają fruktany."
+  substitutions:
+    - "czosnek świeży -> olej czosnkowy"
+    - "czosnek granulowany -> imbir w proszku lub kurkuma"
 ---
 
 Oto przepis na pieczonego łososia w piekarniku z ziemniakami pieczonymi oraz kremowym sosem z szparagów, mascarpone i suszonych pomidorów. Przepis jest łatwy do wykonania i pozwoli uzyskać efektowny obiad z wyrazistym smakiem.

--- a/content/Naleśniki.md
+++ b/content/Naleśniki.md
@@ -16,7 +16,7 @@ calories: 144
 protein: 5
 fat: 6
 carbohydrate: 17
-diets: ["low-fodmap"]
+
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"

--- a/content/Naleśniki.md
+++ b/content/Naleśniki.md
@@ -16,6 +16,14 @@ calories: 144
 protein: 5
 fat: 6
 carbohydrate: 17
+diets: ["low-fodmap"]
+fodmap:
+  status: "no"
+  serving_ok: "Unikaj na diecie Low FODMAP"
+  notes: "Mąka pszenna zawiera gluten i fruktany. Nie jest odpowiednia na diecie Low FODMAP."
+  substitutions:
+    - "mąka pszenna -> mąka ryżowa lub mąka ziemniaczana"
+    - "mleko -> mleko bezlaktozowe lub mleko ryżowe"
 ---
 
 ## Składniki

--- a/content/Omlet Owsiany.md
+++ b/content/Omlet Owsiany.md
@@ -16,7 +16,7 @@ calories: 238
 protein: 13
 fat: 8
 carbohydrate: 30
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Płatki owsiane - maksymalnie 1/2 szklanki (50g) na porcję"

--- a/content/Omlet Owsiany.md
+++ b/content/Omlet Owsiany.md
@@ -16,6 +16,14 @@ calories: 238
 protein: 13
 fat: 8
 carbohydrate: 30
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Płatki owsiane - maksymalnie 1/2 szklanki (50g) na porcję"
+  notes: "Owies w większych ilościach może powodować problemy. Żurawina suszona może zawierać dodatki."
+  substitutions:
+    - "100g płatków owsianych -> 50g płatków owsianych + 25g mąki ryżowej"
+    - "żurawina suszona -> świeże jagody (30g)"
 ---
 
 ## Składniki

--- a/content/Omlet z serem.md
+++ b/content/Omlet z serem.md
@@ -20,10 +20,11 @@ link: https://www.youtube.com/shorts/qb3A_kAPio4
 
 fodmap:
   status: "depends"
-  serving_ok: "Pomidorki cherry - maksymalnie 5 sztuk na porcję"
-  notes: "Uważaj na ilość pomidorków. Czosnek w pesto może być problematyczny."
+  serving_ok: "OK po modyfikacjach: pesto bez czosnku; pomidorki ≤ 5 szt.; ser w małej porcji"
+  notes: "Czosnek w pesto (fruktany) niewskazany. Pomidorki w małej porcji zwykle OK. Sery dojrzewające mają mało laktozy; mozzarella w umiarkowanej porcji."
   substitutions:
     - "pesto z czosnkiem -> pesto bazyliowe bez czosnku lub olej czosnkowy"
+    - "ser -> ser dojrzewający (jeśli wrażliwość na laktozę)"
 ---
 
 ## Składniki

--- a/content/Omlet z serem.md
+++ b/content/Omlet z serem.md
@@ -17,6 +17,13 @@ protein: 13
 fat: 14
 carbohydrate: 2
 link: https://www.youtube.com/shorts/qb3A_kAPio4
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Pomidorki cherry - maksymalnie 5 sztuk na porcję"
+  notes: "Uważaj na ilość pomidorków. Czosnek w pesto może być problematyczny."
+  substitutions:
+    - "pesto z czosnkiem -> pesto bazyliowe bez czosnku lub olej czosnkowy"
 ---
 
 ## Składniki

--- a/content/Omlet z serem.md
+++ b/content/Omlet z serem.md
@@ -17,7 +17,7 @@ protein: 13
 fat: 14
 carbohydrate: 2
 link: https://www.youtube.com/shorts/qb3A_kAPio4
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Pomidorki cherry - maksymalnie 5 sztuk na porcję"

--- a/content/Omleto kanapka z szynką i awokado.md
+++ b/content/Omleto kanapka z szynką i awokado.md
@@ -18,10 +18,13 @@ fat: 8
 carbohydrate: 9
 
 fodmap:
-  status: "yes"
-  serving_ok: "OK w tej porcji"
-  notes: "Jajka, szynka, awokado są bezpieczne"
-  substitutions: []
+  status: "depends"
+  serving_ok: "OK po modyfikacjach: pieczywo bez pszenicy; serek wiejski bez laktozy; awokado ≤ 30 g"
+  notes: "Bułka pszenna (fruktany), serek wiejski (laktoza) i 100 g awokado (sorbitol) nie są zalecane na etapie eliminacji. Jajka są bezpieczne; szynka zwykle OK – sprawdź dodatki (bez cebuli/czosnku)."
+  substitutions:
+    - "bułka pszenna -> 100% kukurydziana tortilla lub pieczywo bezglutenowe (mała porcja)"
+    - "serek wiejski -> wersja bez laktozy lub cienkie plastry sera dojrzewającego"
+    - "awokado 100 g -> ≤ 30 g lub pominąć"
 link: https://www.youtube.com/watch?v=RR5V2Wcxk0w
 ---
 

--- a/content/Omleto kanapka z szynką i awokado.md
+++ b/content/Omleto kanapka z szynką i awokado.md
@@ -16,7 +16,7 @@ calories: 143
 protein: 9
 fat: 8
 carbohydrate: 9
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "OK w tej porcji"

--- a/content/Omleto kanapka z szynką i awokado.md
+++ b/content/Omleto kanapka z szynką i awokado.md
@@ -16,6 +16,12 @@ calories: 143
 protein: 9
 fat: 8
 carbohydrate: 9
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "OK w tej porcji"
+  notes: "Jajka, szynka, awokado są bezpieczne"
+  substitutions: []
 link: https://www.youtube.com/watch?v=RR5V2Wcxk0w
 ---
 

--- a/content/Pieczona Owsianka z malinami.md
+++ b/content/Pieczona Owsianka z malinami.md
@@ -16,6 +16,14 @@ calories: 157
 protein: 6
 fat: 4
 carbohydrate: 26
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Mała porcja - sprawdź napój owsiany"
+  notes: "Owies OK, jogurt grecki OK. Sprawdź skład napoju owsianego"
+  substitutions:
+    - "napój owsiany -> mleko ryżowe lub bezlaktozowe"
+    - "syrop klonowy -> miód (mała ilość)"
 ---
 
 ## Składniki

--- a/content/Pieczona Owsianka z malinami.md
+++ b/content/Pieczona Owsianka z malinami.md
@@ -19,11 +19,12 @@ carbohydrate: 26
 
 fodmap:
   status: "depends"
-  serving_ok: "Mała porcja - sprawdź napój owsiany"
-  notes: "Owies OK, jogurt grecki OK. Sprawdź skład napoju owsianego"
+  serving_ok: "OK w małej porcji; wybierz napój ryżowy lub bez laktozy"
+  notes: "Owies bywa dobrze tolerowany w umiarkowanych porcjach; jogurt grecki zwykle OK (niska laktoza), ale preferuj wersję bez laktozy. Napój owsiany bywa problematyczny – lepiej ryżowy/bezlaktozowy."
   substitutions:
-    - "napój owsiany -> mleko ryżowe lub bezlaktozowe"
-    - "syrop klonowy -> miód (mała ilość)"
+    - "Napój owsiany -> napój ryżowy lub mleko bez laktozy."
+    - "Jogurt grecki -> jogurt bez laktozy."
+    - "Słodzenie: pozostań przy syropie klonowym; unikaj miodu."
 ---
 
 ## Składniki

--- a/content/Pieczona Owsianka z malinami.md
+++ b/content/Pieczona Owsianka z malinami.md
@@ -16,7 +16,7 @@ calories: 157
 protein: 6
 fat: 4
 carbohydrate: 26
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Mała porcja - sprawdź napój owsiany"

--- a/content/Pieczona owsianka bananowo orzechowa z daktylami.md
+++ b/content/Pieczona owsianka bananowo orzechowa z daktylami.md
@@ -18,13 +18,14 @@ fat: 3
 carbohydrate: 26
 
 fodmap:
-  status: "depends"
-  serving_ok: "Mała porcja - uważaj na banany i daktyle"
-  notes: "Daktyle i banany wysokie FODMAP. Owies OK w małych ilościach"
+  status: "no"
+  serving_ok: "Nieodpowiednie na etapie eliminacji"
+  notes: "Daktyle (wysokie FODMAP), dojrzałe banany i miód zwiększają ładunek FODMAP; mleko krowie zawiera laktozę."
   substitutions:
-    - "daktyle -> owoce jagody lub truskawki"
-    - "2 banany -> 1 banan + więcej owsia"
-    - "mleko krowie -> mleko bezlaktozowe"
+    - "Zamień daktyle na maliny/truskawki (≤40–60 g/porcję)."
+    - "Użyj niedojrzałego banana i zmniejsz ilość (maks. 1/3–1/2 na porcję) lub zastąp część owocem jagodowym."
+    - "Mleko -> napój ryżowy lub mleko bez laktozy."
+    - "Miód -> syrop klonowy."
 link: https://www.youtube.com/shorts/mp41DOJiTco
 ---
 

--- a/content/Pieczona owsianka bananowo orzechowa z daktylami.md
+++ b/content/Pieczona owsianka bananowo orzechowa z daktylami.md
@@ -16,6 +16,15 @@ calories: 138
 protein: 4
 fat: 3
 carbohydrate: 26
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Mała porcja - uważaj na banany i daktyle"
+  notes: "Daktyle i banany wysokie FODMAP. Owies OK w małych ilościach"
+  substitutions:
+    - "daktyle -> owoce jagody lub truskawki"
+    - "2 banany -> 1 banan + więcej owsia"
+    - "mleko krowie -> mleko bezlaktozowe"
 link: https://www.youtube.com/shorts/mp41DOJiTco
 ---
 

--- a/content/Pieczona owsianka bananowo orzechowa z daktylami.md
+++ b/content/Pieczona owsianka bananowo orzechowa z daktylami.md
@@ -16,7 +16,7 @@ calories: 138
 protein: 4
 fat: 3
 carbohydrate: 26
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Mała porcja - uważaj na banany i daktyle"

--- a/content/Pierś z Kurczaka Gotowana na Parze z Brązowym Ryżem i Warzywami (Meksykański Twist).md
+++ b/content/Pierś z Kurczaka Gotowana na Parze z Brązowym Ryżem i Warzywami (Meksykański Twist).md
@@ -15,6 +15,14 @@ calories: 144
 protein: 11
 fat: 3
 carbohydrate: 19
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Czerwona fasola - maksymalnie 1/4 szklanki na porcję"
+  notes: "Fasola czerwona może powodować problemy w większych ilościach. Kukurydza i pomidorki są OK."
+  substitutions:
+    - "czerwona fasola -> soczewica czerwona (1/4 szklanki) lub więcej warzyw"
+    - "duża ilość fasoli -> tofu w kostkach lub tempeh"
 ---
 
 ## Składniki

--- a/content/Pierś z Kurczaka Gotowana na Parze z Brązowym Ryżem i Warzywami (Meksykański Twist).md
+++ b/content/Pierś z Kurczaka Gotowana na Parze z Brązowym Ryżem i Warzywami (Meksykański Twist).md
@@ -18,11 +18,12 @@ carbohydrate: 19
 
 fodmap:
   status: "depends"
-  serving_ok: "Czerwona fasola - maksymalnie 1/4 szklanki na porcję"
-  notes: "Fasola czerwona może powodować problemy w większych ilościach. Kukurydza i pomidorki są OK."
+  serving_ok: "OK po modyfikacjach: czerwona fasola ≤ 1/4 szkl.; jogurt bez laktozy; przyprawy bez cebuli/czosnku"
+  notes: "Fasola (GOS) w większej ilości jest problematyczna – ogranicz lub zamień. Jogurt wybierz bez laktozy. Sprawdź mieszanki przypraw, by nie zawierały cebuli/czosnku."
   substitutions:
-    - "czerwona fasola -> soczewica czerwona (1/4 szklanki) lub więcej warzyw"
-    - "duża ilość fasoli -> tofu w kostkach lub tempeh"
+    - "czerwona fasola -> soczewica czerwona z puszki (płukana) ≤ 1/2 szkl. lub więcej warzyw"
+    - "jogurt naturalny -> jogurt bez laktozy"
+    - "mieszanki przypraw -> bez cebuli/czosnku, ewentualnie olej czosnkowy"
 ---
 
 ## Składniki

--- a/content/Pierś z Kurczaka Gotowana na Parze z Brązowym Ryżem i Warzywami (Meksykański Twist).md
+++ b/content/Pierś z Kurczaka Gotowana na Parze z Brązowym Ryżem i Warzywami (Meksykański Twist).md
@@ -15,7 +15,7 @@ calories: 144
 protein: 11
 fat: 3
 carbohydrate: 19
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Czerwona fasola - maksymalnie 1/4 szklanki na porcję"

--- a/content/Placki Marchewkowe.md
+++ b/content/Placki Marchewkowe.md
@@ -16,6 +16,14 @@ calories: 174
 protein: 7
 fat: 7
 carbohydrate: 21
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Marchewka bez ograniczeń, mąka pszenna może być problematyczna"
+  notes: "Marchewka jest bezpieczna. Problem może być w mące pszennej."
+  substitutions:
+    - "mąka pszenna -> mąka ryżowa lub owsiana"
+    - "mleko -> mleko bezlaktozowe"
 ---
 
 ## Składniki

--- a/content/Placki Marchewkowe.md
+++ b/content/Placki Marchewkowe.md
@@ -19,11 +19,11 @@ carbohydrate: 21
 
 fodmap:
   status: "depends"
-  serving_ok: "Marchewka bez ograniczeń, mąka pszenna może być problematyczna"
-  notes: "Marchewka jest bezpieczna. Problem może być w mące pszennej."
+  serving_ok: "OK przy zamianie mąki pszennej i mleka na wersje low FODMAP"
+  notes: "Marchewka jest low FODMAP. Ogranicz pszenicę; wybierz nabiał bez laktozy."
   substitutions:
-    - "mąka pszenna -> mąka ryżowa lub owsiana"
-    - "mleko -> mleko bezlaktozowe"
+    - "Mąka pszenna -> mąka ryżowa lub owsiana bezglutenowa."
+    - "Mleko -> mleko bez laktozy lub napój ryżowy."
 ---
 
 ## Składniki

--- a/content/Placki Marchewkowe.md
+++ b/content/Placki Marchewkowe.md
@@ -16,7 +16,7 @@ calories: 174
 protein: 7
 fat: 7
 carbohydrate: 21
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Marchewka bez ograniczeń, mąka pszenna może być problematyczna"

--- a/content/Placki Z Marchewki I Dyni.md
+++ b/content/Placki Z Marchewki I Dyni.md
@@ -16,7 +16,7 @@ calories: 71
 protein: 3
 fat: 1
 carbohydrate: 14
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Mała porcja - zamień mąkę pszenną"

--- a/content/Placki Z Marchewki I Dyni.md
+++ b/content/Placki Z Marchewki I Dyni.md
@@ -19,12 +19,11 @@ carbohydrate: 14
 
 fodmap:
   status: "depends"
-  serving_ok: "Mała porcja - zamień mąkę pszenną"
-  notes: "Marchewka, dynia, jajko OK. Problem z mąką pszenną"
+  serving_ok: "OK przy małej porcji i zamianie mąki; kontroluj banana"
+  notes: "Marchewka i dynia (w małych porcjach) są low FODMAP. Pszenica i dojrzały banan zwiększają FODMAP."
   substitutions:
-    - "mąka pszenna -> mąka ryżowa"
-    - "mąka pszenna -> mąka owsiana"
-    - "mąka pszenna -> mix mąk bezglutenowych"
+    - "Mąka pszenna -> mąka ryżowa lub owsiana bezglutenowa."
+    - "Dojrzały banan -> niedojrzały i w mniejszej ilości lub zamień na puree z dyni."
 ---
 
 ## Składniki

--- a/content/Placki Z Marchewki I Dyni.md
+++ b/content/Placki Z Marchewki I Dyni.md
@@ -16,6 +16,15 @@ calories: 71
 protein: 3
 fat: 1
 carbohydrate: 14
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Mała porcja - zamień mąkę pszenną"
+  notes: "Marchewka, dynia, jajko OK. Problem z mąką pszenną"
+  substitutions:
+    - "mąka pszenna -> mąka ryżowa"
+    - "mąka pszenna -> mąka owsiana"
+    - "mąka pszenna -> mix mąk bezglutenowych"
 ---
 
 ## Składniki

--- a/content/Placki Z Serka Wiejskiego.md
+++ b/content/Placki Z Serka Wiejskiego.md
@@ -18,7 +18,13 @@ fat: 4
 carbohydrate: 21
 
 fodmap:
-  status: "depends"
+  status: "no"
+  serving_ok: "Nieodpowiednie na etapie eliminacji"
+  notes: "Serek wiejski (laktoza), dojrzały banan i mąka pszenna zwiększają ładunek FODMAP."
+  substitutions:
+    - "Serek wiejski -> wersja bez laktozy lub niewielka porcja sera dojrzewającego."
+    - "Mąka pszenna -> mąka ryżowa lub owsiana bezglutenowa."
+    - "Banan -> niedojrzały i w mniejszej ilości."
   serving_ok: "Mała porcja - zamień mąkę, uważaj na banan"
   notes: "Banan (1/2 max), mąka orkiszowa/pszenna problematyczna"
   substitutions:

--- a/content/Placki Z Serka Wiejskiego.md
+++ b/content/Placki Z Serka Wiejskiego.md
@@ -16,7 +16,7 @@ calories: 158
 protein: 10
 fat: 4
 carbohydrate: 21
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Mała porcja - zamień mąkę, uważaj na banan"

--- a/content/Placki Z Serka Wiejskiego.md
+++ b/content/Placki Z Serka Wiejskiego.md
@@ -16,6 +16,15 @@ calories: 158
 protein: 10
 fat: 4
 carbohydrate: 21
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Mała porcja - zamień mąkę, uważaj na banan"
+  notes: "Banan (1/2 max), mąka orkiszowa/pszenna problematyczna"
+  substitutions:
+    - "mąka pszenna/orkiszowa -> mąka ryżowa"
+    - "duży banan -> 1/2 banana"
+    - "serek wiejski -> sprawdź czy bezlaktozowy"
 ---
 
 ## Składniki

--- a/content/Placki bananowe.md
+++ b/content/Placki bananowe.md
@@ -16,6 +16,14 @@ protein: 7
 fat: 3
 carbohydrate: 22
 link: https://youtu.be/3qI4Y5dRumA?t=254
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "1 średni banan (maksymalnie 1/3 dużego banana) na porcję"
+  notes: "Banany są bezpieczne w małych ilościach. Unikaj mąki pszennej w dużych ilościach."
+  substitutions:
+    - "mąka pszenna -> mąka owsiana lub mąka ryżowa"
+    - "duży banan -> 1/3 dużego banana + więcej jogurtu"
 ---
 
 ## Składniki

--- a/content/Placki bananowe.md
+++ b/content/Placki bananowe.md
@@ -19,11 +19,11 @@ link: https://youtu.be/3qI4Y5dRumA?t=254
 
 fodmap:
   status: "depends"
-  serving_ok: "1 średni banan (maksymalnie 1/3 dużego banana) na porcję"
-  notes: "Banany są bezpieczne w małych ilościach. Unikaj mąki pszennej w dużych ilościach."
+  serving_ok: "OK przy małej porcji; użyj niedojrzałego banana (≤1/2 szt. na porcję)"
+  notes: "Dojrzałe banany są wysokie FODMAP – wybieraj niedojrzałe i ogranicz ilość. Rozważ zamianę mąki pszennej."
   substitutions:
-    - "mąka pszenna -> mąka owsiana lub mąka ryżowa"
-    - "duży banan -> 1/3 dużego banana + więcej jogurtu"
+    - "Mąka pszenna -> mąka owsiana bezglutenowa lub ryżowa."
+    - "Zmniejsz banana -> dodaj więcej jogurtu/skyr bez laktozy."
 ---
 
 ## Składniki

--- a/content/Placki bananowe.md
+++ b/content/Placki bananowe.md
@@ -16,7 +16,7 @@ protein: 7
 fat: 3
 carbohydrate: 22
 link: https://youtu.be/3qI4Y5dRumA?t=254
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "1 średni banan (maksymalnie 1/3 dużego banana) na porcję"

--- a/content/Salatka-Grecka.md
+++ b/content/Salatka-Grecka.md
@@ -14,7 +14,7 @@ calories: 86
 protein: 3
 fat: 6
 carbohydrate: 5
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Mała porcja - unikaj czerwonej cebuli"

--- a/content/Salatka-Grecka.md
+++ b/content/Salatka-Grecka.md
@@ -17,12 +17,10 @@ carbohydrate: 5
 
 fodmap:
   status: "depends"
-  serving_ok: "Mała porcja - unikaj czerwonej cebuli"
-  notes: "Pomidory, ogórek, feta, oliwki OK. Problem z czerwoną cebulą"
+  serving_ok: "OK po modyfikacjach: bez czerwonej cebuli; feta w małej porcji (~30–40 g/os.)"
+  notes: "Pomidory, ogórek, oliwki są zwykle dobrze tolerowane. Czerwona cebula jest wysokofodmapowa – zamień na szczypiorek. Feta bywa akceptowalna w małej porcji."
   substitutions:
-    - "czerwona cebula -> dymka (zielone części)"
-    - "czerwona cebula -> posypka ze szczypiorku"
-    - "lub zrób bez cebuli"
+    - "czerwona cebula -> szczypiorek/zielona część dymki"
 ---
 
 ## Składniki

--- a/content/Salatka-Grecka.md
+++ b/content/Salatka-Grecka.md
@@ -14,6 +14,15 @@ calories: 86
 protein: 3
 fat: 6
 carbohydrate: 5
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Mała porcja - unikaj czerwonej cebuli"
+  notes: "Pomidory, ogórek, feta, oliwki OK. Problem z czerwoną cebulą"
+  substitutions:
+    - "czerwona cebula -> dymka (zielone części)"
+    - "czerwona cebula -> posypka ze szczypiorku"
+    - "lub zrób bez cebuli"
 ---
 
 ## Składniki

--- a/content/Sos Majonezowy Z Limonką.md
+++ b/content/Sos Majonezowy Z Limonką.md
@@ -15,6 +15,12 @@ calories: 35
 protein: 1
 fat: 3
 carbohydrate: 1
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "Bez ograniczeń"
+  notes: "Wszystkie składniki są bezpieczne na diecie Low FODMAP."
+  substitutions: []
 ---
 
 Lekki sos majonezowy z nutą limonki i ostrą papryką to doskonały dodatek do grillowanych mięs, warzyw na parze czy sałatek. Dzięki połączeniu majonezu light z jogurtem naturalnym sos jest znacznie mniej kaloryczny niż tradycyjny majonez, a sok z limonki nadaje mu świeży, cytrusowy smak.

--- a/content/Sos Majonezowy Z Limonką.md
+++ b/content/Sos Majonezowy Z Limonką.md
@@ -18,9 +18,10 @@ carbohydrate: 1
 
 fodmap:
   status: "yes"
-  serving_ok: "Bez ograniczeń"
-  notes: "Wszystkie składniki są bezpieczne na diecie Low FODMAP."
-  substitutions: []
+  serving_ok: "OK przy użyciu jogurtu bez laktozy"
+  notes: "Majonez i cytrusy są OK; jogurt wybierz bez laktozy."
+  substitutions:
+    - "Jogurt naturalny -> jogurt bez laktozy."
 ---
 
 Lekki sos majonezowy z nutą limonki i ostrą papryką to doskonały dodatek do grillowanych mięs, warzyw na parze czy sałatek. Dzięki połączeniu majonezu light z jogurtem naturalnym sos jest znacznie mniej kaloryczny niż tradycyjny majonez, a sok z limonki nadaje mu świeży, cytrusowy smak.

--- a/content/Sos Majonezowy Z Limonką.md
+++ b/content/Sos Majonezowy Z Limonką.md
@@ -15,7 +15,7 @@ calories: 35
 protein: 1
 fat: 3
 carbohydrate: 1
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "Bez ograniczeń"

--- a/content/Sos Szparagowy Z Mascarpone.md
+++ b/content/Sos Szparagowy Z Mascarpone.md
@@ -15,6 +15,12 @@ calories: 238
 protein: 7
 fat: 19
 carbohydrate: 12
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "OK w tej porcji"
+  notes: "Szparagi, mascarpone, suszone pomidory są bezpieczne"
+  substitutions: []
 ---
 
 Kremowy sos szparagowy z mascarpone i suszonymi pomidorami to doskonały dodatek do ryb, mięsa drobiowego czy pieczonego mięsa. Sos ma delikatny smak szparagów wzbogacony kremowością mascarpone i słonawą nutą suszonych pomidorów.

--- a/content/Sos Szparagowy Z Mascarpone.md
+++ b/content/Sos Szparagowy Z Mascarpone.md
@@ -15,7 +15,7 @@ calories: 238
 protein: 7
 fat: 19
 carbohydrate: 12
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "OK w tej porcji"

--- a/content/Sos Szparagowy Z Mascarpone.md
+++ b/content/Sos Szparagowy Z Mascarpone.md
@@ -17,10 +17,12 @@ fat: 19
 carbohydrate: 12
 
 fodmap:
-  status: "yes"
-  serving_ok: "OK w tej porcji"
-  notes: "Szparagi, mascarpone, suszone pomidory są bezpieczne"
-  substitutions: []
+  status: "depends"
+  serving_ok: "OK po modyfikacjach: usuń czosnek, kontroluj suszone pomidory (≤10–12 g/os.)"
+  notes: "Mascarpone ma wysoką laktozę; czosnek i większe ilości suszonych pomidorów zwiększają FODMAP."
+  substitutions:
+    - "Mascarpone -> śmietanka bez laktozy lub ser twardy (np. cheddar) rozpuszczony w sosie."
+    - "Czosnek -> olej czosnkowy."
 ---
 
 Kremowy sos szparagowy z mascarpone i suszonymi pomidorami to doskonały dodatek do ryb, mięsa drobiowego czy pieczonego mięsa. Sos ma delikatny smak szparagów wzbogacony kremowością mascarpone i słonawą nutą suszonych pomidorów.

--- a/content/Szakszuka.md
+++ b/content/Szakszuka.md
@@ -16,6 +16,14 @@ calories: 114
 protein: 6
 fat: 7
 carbohydrate: 7
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Sprawdź skład pesto - unikaj czosnku"
+  notes: "Pomidory i jajka są OK. Problem może być w czosnku."
+  substitutions:
+    - "czosnek -> olej czosnkowy"
+    - "pesto z czosnkiem -> pesto bazyliowe bez czosnku"
 ---
 
 ## Składniki

--- a/content/Szakszuka.md
+++ b/content/Szakszuka.md
@@ -18,12 +18,12 @@ fat: 7
 carbohydrate: 7
 
 fodmap:
-  status: "depends"
-  serving_ok: "Sprawdź skład pesto - unikaj czosnku"
-  notes: "Pomidory i jajka są OK. Problem może być w czosnku."
+  status: "no"
+  serving_ok: "Nieodpowiednie w obecnej wersji (cebula, czosnek, mascarpone)"
+  notes: "Cebula i czosnek (fruktany) są niewskazane; mascarpone to wysoka laktoza."
   substitutions:
-    - "czosnek -> olej czosnkowy"
-    - "pesto z czosnkiem -> pesto bazyliowe bez czosnku"
+    - "Cebula/czosnek -> zielona część dymki + olej czosnkowy."
+    - "Mascarpone -> ser twardy (np. cheddar) lub niewielka porcja śmietanki bez laktozy."
 ---
 
 ## Składniki

--- a/content/Szakszuka.md
+++ b/content/Szakszuka.md
@@ -16,7 +16,7 @@ calories: 114
 protein: 6
 fat: 7
 carbohydrate: 7
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Sprawdź skład pesto - unikaj czosnku"

--- a/content/Tortilla z jajecznicą.md
+++ b/content/Tortilla z jajecznicą.md
@@ -16,6 +16,14 @@ calories: 168
 protein: 10
 fat: 8
 carbohydrate: 15
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Sprawdź skład tortilli - unikaj pszenicy pełnoziarnistej"
+  notes: "Jajka są OK. Problem z pełnoziarnistą tortillą (więcej błonnika)"
+  substitutions:
+    - "tortilla pełnoziarnista -> tortilla kukurydziana"
+    - "tortilla pszenna -> tortilla ryżowa"
 link: https://youtu.be/3qI4Y5dRumA?t=174
 ---
 

--- a/content/Tortilla z jajecznicą.md
+++ b/content/Tortilla z jajecznicą.md
@@ -19,6 +19,10 @@ carbohydrate: 15
 
 fodmap:
   status: "depends"
+  serving_ok: "OK po zamianie tortilli pszennej i bez dodatków cebuli/czosnku"
+  notes: "Jajka są OK; tortille pszenne zawierają fruktany."
+  substitutions:
+    - "Tortilla pełnoziarnista -> 100% kukurydziana."
   serving_ok: "Sprawdź skład tortilli - unikaj pszenicy pełnoziarnistej"
   notes: "Jajka są OK. Problem z pełnoziarnistą tortillą (więcej błonnika)"
   substitutions:

--- a/content/Tortilla z jajecznicą.md
+++ b/content/Tortilla z jajecznicą.md
@@ -16,7 +16,7 @@ calories: 168
 protein: 10
 fat: 8
 carbohydrate: 15
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Sprawdź skład tortilli - unikaj pszenicy pełnoziarnistej"

--- a/content/Wrap Z Awokado I Jajkiem.md
+++ b/content/Wrap Z Awokado I Jajkiem.md
@@ -16,6 +16,14 @@ calories: 141
 protein: 8
 fat: 9
 carbohydrate: 10
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Zamień tortillę pełnoziarnistą na kukurydzianą"
+  notes: "Awokado, jajka, pomidor są OK. Problem z pełnoziarnistą tortillą"
+  substitutions:
+    - "tortilla pełnoziarnista -> tortilla kukurydziana"
+    - "tortilla pszenna -> tortilla ryżowa"
 ---
 
 ## Składniki

--- a/content/Wrap Z Awokado I Jajkiem.md
+++ b/content/Wrap Z Awokado I Jajkiem.md
@@ -16,7 +16,7 @@ calories: 141
 protein: 8
 fat: 9
 carbohydrate: 10
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Zamień tortillę pełnoziarnistą na kukurydzianą"

--- a/content/Wrap Z Awokado I Jajkiem.md
+++ b/content/Wrap Z Awokado I Jajkiem.md
@@ -19,6 +19,12 @@ carbohydrate: 10
 
 fodmap:
   status: "depends"
+  serving_ok: "OK po modyfikacjach: mała porcja awokado i bez cebuli/czosnku"
+  notes: "Awokado wysokie FODMAP w większych porcjach (sorbitol); cebula/czosnek granulowane niewskazane; tortilla pszenna to pszenica."
+  substitutions:
+    - "Tortilla pełnoziarnista -> 100% kukurydziana."
+    - "Czosnek/cebula granulowana -> olej czosnkowy + szczypiorek."
+    - "Awokado -> maks. 30 g na porcję lub pominąć."
   serving_ok: "Zamień tortillę pełnoziarnistą na kukurydzianą"
   notes: "Awokado, jajka, pomidor są OK. Problem z pełnoziarnistą tortillą"
   substitutions:

--- a/content/Wysokobiałkowy Pudding Truskawkowo-Bananowy z Polewą Czekoladowo-Orzechową.md
+++ b/content/Wysokobiałkowy Pudding Truskawkowo-Bananowy z Polewą Czekoladowo-Orzechową.md
@@ -16,6 +16,15 @@ calories: 133
 protein: 7
 fat: 4
 carbohydrate: 15
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Mała porcja - uważaj na banany i napój owsiany"
+  notes: "Banany (1/2 na porcję), mleko owsiane może zawierać błonnik"
+  substitutions:
+    - "mleko owsiane -> mleko ryżowe lub bezlaktozowe"
+    - "duże banany -> małe banany lub mniej"
+    - "dodaj więcej truskawek zamiast bananów"
 link: https://youtu.be/SQ4saBQrBYc?t=115
 ---
 

--- a/content/Wysokobiałkowy Pudding Truskawkowo-Bananowy z Polewą Czekoladowo-Orzechową.md
+++ b/content/Wysokobiałkowy Pudding Truskawkowo-Bananowy z Polewą Czekoladowo-Orzechową.md
@@ -19,12 +19,12 @@ carbohydrate: 15
 
 fodmap:
   status: "depends"
-  serving_ok: "Mała porcja - uważaj na banany i napój owsiany"
-  notes: "Banany (1/2 na porcję), mleko owsiane może zawierać błonnik"
+  serving_ok: "OK po modyfikacjach: nabiał bez laktozy; napój ryżowy; banan ≤ 1/2 na porcję"
+  notes: "Płatki owsiane zwykle OK w umiarkowanej porcji; banany podnoszą FODMAP przy większej ilości. Twaróg wymaga wersji bez laktozy; unikaj napoju owsianego."
   substitutions:
-    - "mleko owsiane -> mleko ryżowe lub bezlaktozowe"
-    - "duże banany -> małe banany lub mniej"
-    - "dodaj więcej truskawek zamiast bananów"
+    - "twaróg -> skyr/twaróg bez laktozy"
+    - "napój owsiany -> napój ryżowy lub mleko bez laktozy"
+    - "część banana -> więcej truskawek"
 link: https://youtu.be/SQ4saBQrBYc?t=115
 ---
 

--- a/content/Wysokobiałkowy Pudding Truskawkowo-Bananowy z Polewą Czekoladowo-Orzechową.md
+++ b/content/Wysokobiałkowy Pudding Truskawkowo-Bananowy z Polewą Czekoladowo-Orzechową.md
@@ -16,7 +16,7 @@ calories: 133
 protein: 7
 fat: 4
 carbohydrate: 15
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Mała porcja - uważaj na banany i napój owsiany"

--- a/content/Wysokobiałkowy Serniczek.md
+++ b/content/Wysokobiałkowy Serniczek.md
@@ -15,7 +15,7 @@ calories: 112
 protein: 9
 fat: 4
 carbohydrate: 10
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "OK w tej porcji"

--- a/content/Wysokobiałkowy Serniczek.md
+++ b/content/Wysokobiałkowy Serniczek.md
@@ -15,6 +15,12 @@ calories: 112
 protein: 9
 fat: 4
 carbohydrate: 10
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "OK w tej porcji"
+  notes: "Jajka, skyr, erytrol są bezpieczne. Sprawdź skład budyniu"
+  substitutions: []
 link: https://www.youtube.com/watch?v=SspgxK9oPdY
 ---
 

--- a/content/Wysokobiałkowy Serniczek.md
+++ b/content/Wysokobiałkowy Serniczek.md
@@ -17,10 +17,12 @@ fat: 4
 carbohydrate: 10
 
 fodmap:
-  status: "yes"
-  serving_ok: "OK w tej porcji"
-  notes: "Jajka, skyr, erytrol są bezpieczne. Sprawdź skład budyniu"
-  substitutions: []
+  status: "depends"
+  serving_ok: "OK przy nabiale bez laktozy i umiarkowanej porcji"
+  notes: "Skyr i proszek budyniowy mogą zawierać laktozę; wybierz wersje bez laktozy."
+  substitutions:
+    - "Skyr -> skyr bez laktozy."
+    - "Budyń -> budyń przygotowany na mleku bez laktozy lub napoju ryżowym."
 link: https://www.youtube.com/watch?v=SspgxK9oPdY
 ---
 

--- a/content/Zapiekanka Ziemniaczana z Cukinią i Mięsem Mielonym.md
+++ b/content/Zapiekanka Ziemniaczana z Cukinią i Mięsem Mielonym.md
@@ -18,6 +18,12 @@ carbohydrate: 11
 
 fodmap:
   status: "depends"
+  serving_ok: "Nieodpowiednie w obecnej wersji (cebula, czosnek, fasola, śmietanka)"
+  notes: "Cebula/czosnek (fruktany), fasola (GOS) i śmietanka (laktoza) podnoszą FODMAP. Ziemniaki i cukinia są OK w umiarkowanych porcjach."
+  substitutions:
+    - "Cebula/czosnek -> zielona część dymki + olej czosnkowy."
+    - "Fasola -> pominąć lub zamienić na marchewkę/cukinię."
+    - "Śmietanka -> śmietanka bez laktozy."
   serving_ok: "Mała porcja - unikaj cebuli i czosnku"
   notes: "Ziemniaki, cukinia, mięso OK. Problem z cebulą i czosnkiem"
   substitutions:

--- a/content/Zapiekanka Ziemniaczana z Cukinią i Mięsem Mielonym.md
+++ b/content/Zapiekanka Ziemniaczana z Cukinią i Mięsem Mielonym.md
@@ -15,6 +15,15 @@ calories: 161
 protein: 11
 fat: 8
 carbohydrate: 11
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Mała porcja - unikaj cebuli i czosnku"
+  notes: "Ziemniaki, cukinia, mięso OK. Problem z cebulą i czosnkiem"
+  substitutions:
+    - "cebula -> dymka (zielone części)"
+    - "czosnek -> olej czosnkowy"
+    - "lub gotuj bez cebuli i czosnku"
 ---
 
 ## Składniki

--- a/content/Zapiekanka Ziemniaczana z Cukinią i Mięsem Mielonym.md
+++ b/content/Zapiekanka Ziemniaczana z Cukinią i Mięsem Mielonym.md
@@ -15,7 +15,7 @@ calories: 161
 protein: 11
 fat: 8
 carbohydrate: 11
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Mała porcja - unikaj cebuli i czosnku"

--- a/content/Zdrowy Deser w Stylu Snickersa.md
+++ b/content/Zdrowy Deser w Stylu Snickersa.md
@@ -18,6 +18,11 @@ carbohydrate: 15
 
 fodmap:
   status: "depends"
+  serving_ok: "OK przy małej porcji banana i jogurcie bez laktozy"
+  notes: "Banan w większej porcji i jogurt ze zwykłym mlekiem mogą podnosić FODMAP; orzechy ziemne zwykle OK w małych ilościach."
+  substitutions:
+    - "Skyr waniliowy -> wersja bez laktozy."
+    - "Banan -> ≤1/2 niedojrzałego banana."
   serving_ok: "Używaj małego banana lub 1/2 banana"
   notes: "Skyr i masło orzechowe OK. Uważaj na wielkość banana"
   substitutions:

--- a/content/Zdrowy Deser w Stylu Snickersa.md
+++ b/content/Zdrowy Deser w Stylu Snickersa.md
@@ -15,6 +15,15 @@ calories: 172
 protein: 8
 fat: 10
 carbohydrate: 15
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Używaj małego banana lub 1/2 banana"
+  notes: "Skyr i masło orzechowe OK. Uważaj na wielkość banana"
+  substitutions:
+    - "duży banan -> 1/2 banana + więcej skyru"
+    - "orzechy włoskie -> orzechy pekan (bezpieczne)"
+    - "migdały -> małe porcje (max 10 sztuk)"
 link: https://www.youtube.com/watch?v=KoaGLBK5rhI
 ---
 

--- a/content/Zdrowy Deser w Stylu Snickersa.md
+++ b/content/Zdrowy Deser w Stylu Snickersa.md
@@ -15,7 +15,7 @@ calories: 172
 protein: 8
 fat: 10
 carbohydrate: 15
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Używaj małego banana lub 1/2 banana"

--- a/content/diets/_index.md
+++ b/content/diets/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Diety"
+draft: true
+---
+
+Lista dostępnych diet. Wybierz interesującą Cię dietę, aby zobaczyć pasujące przepisy.

--- a/content/diets/low-fodmap/_index.md
+++ b/content/diets/low-fodmap/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Low FODMAP"
-draft: true
+title: "low-fodmap"
+type: "diet"
 ---
 
 Przepisy dostosowane do diety Low FODMAP.

--- a/content/diets/low-fodmap/_index.md
+++ b/content/diets/low-fodmap/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Low FODMAP"
+draft: true
+---
+
+Przepisy dostosowane do diety Low FODMAP.

--- a/content/fasola po bretonsku.md
+++ b/content/fasola po bretonsku.md
@@ -20,6 +20,10 @@ link: https://www.youtube.com/watch?v=RwzTn7o7OkY
 
 fodmap:
   status: "no"
+  serving_ok: "Nieodpowiednie na diecie Low FODMAP"
+  notes: "Fasola sucha (GOS), cebula i czosnek – wysoki ładunek FODMAP."
+  substitutions:
+    - "Brak bezpośrednich – rozważ wersję z większą ilością marchewki i bez roślin strączkowych."
   serving_ok: "Unikaj na diecie Low FODMAP"
   notes: "Cebula, czosnek i duże ilości fasoli - wysokie FODMAP."
   substitutions:

--- a/content/fasola po bretonsku.md
+++ b/content/fasola po bretonsku.md
@@ -17,7 +17,7 @@ protein: 11
 fat: 9
 carbohydrate: 20 
 link: https://www.youtube.com/watch?v=RwzTn7o7OkY
-diets: ["low-fodmap"]
+
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"

--- a/content/fasola po bretonsku.md
+++ b/content/fasola po bretonsku.md
@@ -16,7 +16,16 @@ calories: 200
 protein: 11
 fat: 9
 carbohydrate: 20 
-link: https://www.youtube.com/watch?v=RwzTn7o7OkY  
+link: https://www.youtube.com/watch?v=RwzTn7o7OkY
+diets: ["low-fodmap"]
+fodmap:
+  status: "no"
+  serving_ok: "Unikaj na diecie Low FODMAP"
+  notes: "Cebula, czosnek i duże ilości fasoli - wysokie FODMAP."
+  substitutions:
+    - "cebula -> zielona część dymki"
+    - "czosnek -> olej czosnkowy"
+    - "fasola biała -> soczewica czerwona w małych ilościach"
 ---
 
 ## Składniki

--- a/content/fritatta_z_batatami.md
+++ b/content/fritatta_z_batatami.md
@@ -17,7 +17,7 @@ protein: 6.2
 fat: 5.3
 carbohydrate: 9.2
 link: https://www.youtube.com/watch?v=prsZbulipCk
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Czerwona cebula - maksymalnie 2 łyżki na porcję"

--- a/content/fritatta_z_batatami.md
+++ b/content/fritatta_z_batatami.md
@@ -20,11 +20,11 @@ link: https://www.youtube.com/watch?v=prsZbulipCk
 
 fodmap:
   status: "depends"
-  serving_ok: "Czerwona cebula - maksymalnie 2 łyżki na porcję"
-  notes: "Bataty, jajka, papryka i szpinak są OK. Uważaj na ilość cebuli."
+  serving_ok: "OK bez cebuli; bataty do ~75–100 g/porcję; feta ~30–40 g/porcję"
+  notes: "Cebula (fruktany) niewskazana – użyj tylko zielonych części dymki. Bataty zawierają mannitol – zachowaj umiarkowaną porcję (~75–100 g na osobę). Feta jest zwykle OK w małej porcji."
   substitutions:
-    - "czerwona cebula -> zielona część dymki"
-    - "duża ilość cebuli -> więcej papryki i szpinaku"
+    - "czerwona cebula -> zielona część dymki / szczypior"
+    - "za dużo batatów -> mniejsza porcja lub więcej papryki/szpinaku"
 ---
 
 ## Składniki

--- a/content/fritatta_z_batatami.md
+++ b/content/fritatta_z_batatami.md
@@ -17,6 +17,14 @@ protein: 6.2
 fat: 5.3
 carbohydrate: 9.2
 link: https://www.youtube.com/watch?v=prsZbulipCk
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Czerwona cebula - maksymalnie 2 łyżki na porcję"
+  notes: "Bataty, jajka, papryka i szpinak są OK. Uważaj na ilość cebuli."
+  substitutions:
+    - "czerwona cebula -> zielona część dymki"
+    - "duża ilość cebuli -> więcej papryki i szpinaku"
 ---
 
 ## Składniki

--- a/content/giga_omlet_warzywny.md
+++ b/content/giga_omlet_warzywny.md
@@ -17,6 +17,15 @@ protein: 7.8
 fat: 4.4  
 carbohydrate: 8.6  
 link: https://www.youtube.com/watch?v=wDmemjiyK4w&t=306s
+diets: ["low-fodmap"]
+fodmap:
+  status: "no"
+  serving_ok: "Unikaj na diecie Low FODMAP"
+  notes: "Cebula, czosnek i mąka pszenna - wysokie FODMAP."
+  substitutions:
+    - "cebula czerwona -> zielona część dymki"
+    - "czosnek -> olej czosnkowy"
+    - "mąka pszenna -> mąka ryżowa lub ziemniaczana"
 ---
 
 ## Składniki

--- a/content/giga_omlet_warzywny.md
+++ b/content/giga_omlet_warzywny.md
@@ -21,11 +21,11 @@ link: https://www.youtube.com/watch?v=wDmemjiyK4w&t=306s
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"
-  notes: "Cebula, czosnek i mąka pszenna - wysokie FODMAP."
+  notes: "Cebula i czosnek (fruktany) oraz mąka pszenna (fruktany) czynią to danie nieodpowiednim."
   substitutions:
-    - "cebula czerwona -> zielona część dymki"
-    - "czosnek -> olej czosnkowy"
-    - "mąka pszenna -> mąka ryżowa lub ziemniaczana"
+    - "cebula czerwona -> zielona część dymki/szczypior"
+    - "czosnek -> olej czosnkowy lub asafetyda"
+    - "mąka pszenna -> mąka ryżowa/ziemniaczana (GF)"
 ---
 
 ## Składniki

--- a/content/giga_omlet_warzywny.md
+++ b/content/giga_omlet_warzywny.md
@@ -17,7 +17,7 @@ protein: 7.8
 fat: 4.4  
 carbohydrate: 8.6  
 link: https://www.youtube.com/watch?v=wDmemjiyK4w&t=306s
-diets: ["low-fodmap"]
+
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"

--- a/content/golabki_leniwe.md
+++ b/content/golabki_leniwe.md
@@ -15,6 +15,14 @@ calories: 82
 protein: 5
 fat: 5
 carbohydrate: 4
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Kapusta - maksymalnie 1 szklanka pokrojonej na porcję"
+  notes: "Unikaj czosnku. Kapusta w umiarkowanych ilościach jest OK."
+  substitutions:
+    - "czosnek -> olej czosnkowy"
+    - "dużo kapusty -> połowa kapusty + więcej mięsa"
 ---
 
 ## Składniki

--- a/content/golabki_leniwe.md
+++ b/content/golabki_leniwe.md
@@ -18,11 +18,12 @@ carbohydrate: 4
 
 fodmap:
   status: "depends"
-  serving_ok: "Kapusta - maksymalnie 1 szklanka pokrojonej na porcję"
-  notes: "Unikaj czosnku. Kapusta w umiarkowanych ilościach jest OK."
+  serving_ok: "OK po modyfikacjach: bez czosnku; śmietana bez laktozy; kapusta w umiarkowanej porcji (~75–90 g/porcję)"
+  notes: "Czosnek (fruktany) jest niewskazany, śmietana zawiera laktozę. Kapusta biała jest akceptowalna w małej/umiarkowanej porcji."
   substitutions:
-    - "czosnek -> olej czosnkowy"
-    - "dużo kapusty -> połowa kapusty + więcej mięsa"
+    - "czosnek -> olej czosnkowy (bez cząstek)"
+    - "śmietana 30% -> śmietanka bez laktozy lub pominąć"
+    - "duża ilość kapusty -> mniejsza porcja kapusty + więcej mięsa/sosu pomidorowego"
 ---
 
 ## Składniki

--- a/content/golabki_leniwe.md
+++ b/content/golabki_leniwe.md
@@ -15,7 +15,7 @@ calories: 82
 protein: 5
 fat: 5
 carbohydrate: 4
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Kapusta - maksymalnie 1 szklanka pokrojonej na porcję"

--- a/content/granola.md
+++ b/content/granola.md
@@ -17,6 +17,15 @@ protein: 10
 fat: 24
 carbohydrate: 54
 link: https://www.youtube.com/watch?v=xsvyi8sl8xM
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Maksymalnie 1/4 szklanki (30g) na porcję"
+  notes: "Płatki owsiane i orzechy w małych ilościach są OK. Miód może być problematyczny."
+  substitutions:
+    - "miód -> syrop klonowy (w tej samej ilości)"
+    - "duża porcja -> mniejsza porcja z jogurtem"
+    - "orzechy włoskie -> orzechie pekan lub migdały (małe ilości)"
 ---
 
 ## Składniki

--- a/content/granola.md
+++ b/content/granola.md
@@ -20,12 +20,12 @@ link: https://www.youtube.com/watch?v=xsvyi8sl8xM
 
 fodmap:
   status: "depends"
-  serving_ok: "Maksymalnie 1/4 szklanki (30g) na porcję"
-  notes: "Płatki owsiane i orzechy w małych ilościach są OK. Miód może być problematyczny."
+  serving_ok: "Porcja ~30 g; podawać z nabiałem bez laktozy lub napojem ryżowym"
+  notes: "Miód jest wysokofodmapowy – zamień na syrop klonowy. Suszone owoce szybko podbijają FODMAP – ogranicz lub pomiń. Płatki owsiane i orzechy są OK w małej porcji."
   substitutions:
-    - "miód -> syrop klonowy (w tej samej ilości)"
-    - "duża porcja -> mniejsza porcja z jogurtem"
-    - "orzechy włoskie -> orzechie pekan lub migdały (małe ilości)"
+    - "miód -> syrop klonowy"
+    - "suszone morele/żurawina -> bardzo mała ilość lub pominąć"
+    - "jogurt zwykły -> jogurt/skyr bez laktozy lub napój ryżowy"
 ---
 
 ## Składniki

--- a/content/granola.md
+++ b/content/granola.md
@@ -17,7 +17,7 @@ protein: 10
 fat: 24
 carbohydrate: 54
 link: https://www.youtube.com/watch?v=xsvyi8sl8xM
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Maksymalnie 1/4 szklanki (30g) na porcję"

--- a/content/jagodzianki taty.md
+++ b/content/jagodzianki taty.md
@@ -18,13 +18,13 @@ carbohydrate: 44
 link:   
 
 fodmap:
-  status: "no"
-  serving_ok: "Unikaj na diecie Low FODMAP"
+   status: "no"
+   serving_ok: "Unikaj na diecie Low FODMAP"
    notes: "Mąka pszenna i fermentacja drożdżowa sprzyjają fruktanom."
-  substitutions:
+   substitutions:
       - "mąka pszenna -> mąka ryżowa lub mieszanka bezglutenowa"
       - "drożdże -> proszek do pieczenia (BG)"
-    - "mleko -> mleko bezlaktozowe"
+      - "mleko -> mleko bezlaktozowe"
 ---
 
 ## Składniki

--- a/content/jagodzianki taty.md
+++ b/content/jagodzianki taty.md
@@ -16,6 +16,15 @@ protein: 7
 fat: 9  
 carbohydrate: 44  
 link:   
+diets: ["low-fodmap"]
+fodmap:
+  status: "no"
+  serving_ok: "Unikaj na diecie Low FODMAP"
+  notes: "Mąka pszenna z drożdżami zawiera wysokie poziomy fruktatów."
+  substitutions:
+    - "mąka pszenna -> mąka ryżowa lub bezglutenowa mieszanka"
+    - "drożdże -> proszek do pieczenia bezglutenowy"
+    - "mleko -> mleko bezlaktozowe"
 ---
 
 ## Składniki

--- a/content/jagodzianki taty.md
+++ b/content/jagodzianki taty.md
@@ -16,7 +16,7 @@ protein: 7
 fat: 9  
 carbohydrate: 44  
 link:   
-diets: ["low-fodmap"]
+
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"

--- a/content/jagodzianki taty.md
+++ b/content/jagodzianki taty.md
@@ -20,10 +20,10 @@ link:
 fodmap:
   status: "no"
   serving_ok: "Unikaj na diecie Low FODMAP"
-  notes: "Mąka pszenna z drożdżami zawiera wysokie poziomy fruktatów."
+   notes: "Mąka pszenna i fermentacja drożdżowa sprzyjają fruktanom."
   substitutions:
-    - "mąka pszenna -> mąka ryżowa lub bezglutenowa mieszanka"
-    - "drożdże -> proszek do pieczenia bezglutenowy"
+      - "mąka pszenna -> mąka ryżowa lub mieszanka bezglutenowa"
+      - "drożdże -> proszek do pieczenia (BG)"
     - "mleko -> mleko bezlaktozowe"
 ---
 

--- a/content/karkowka.md
+++ b/content/karkowka.md
@@ -16,7 +16,7 @@ protein: 25
 fat: 18
 carbohydrate: 8
 link: https://www.youtube.com/watch?v=U0RCUwb7as4
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Unikaj marynaty z czosnkiem i cebulą"

--- a/content/karkowka.md
+++ b/content/karkowka.md
@@ -19,11 +19,11 @@ link: https://www.youtube.com/watch?v=U0RCUwb7as4
 
 fodmap:
   status: "depends"
-  serving_ok: "Unikaj marynaty z czosnkiem i cebulą"
-  notes: "Sama karkówka jest OK. Problem w składnikach marynaty."
+  serving_ok: "OK po modyfikacjach: marynata bez cebuli/czosnku; miód zamienić na syrop klonowy"
+  notes: "Mięso jest low FODMAP. Źródłem FODMAP są dodatki w marynacie (czosnek/cebula/honey). Użyj past bez cebuli/czosnku i słodź syropem klonowym."
   substitutions:
-    - "czosnek w marynacie -> olej czosnkowy"
-    - "cebula -> zielona część dymki"
+    - "czosnek -> olej czosnkowy (bez cząstek)"
+    - "cebula -> zielona część dymki/szczypior"
     - "miód -> syrop klonowy"
 ---
 

--- a/content/karkowka.md
+++ b/content/karkowka.md
@@ -15,7 +15,16 @@ calories: 285
 protein: 25
 fat: 18
 carbohydrate: 8
-link: https://www.youtube.com/watch?v=U0RCUwb7as4  
+link: https://www.youtube.com/watch?v=U0RCUwb7as4
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Unikaj marynaty z czosnkiem i cebulą"
+  notes: "Sama karkówka jest OK. Problem w składnikach marynaty."
+  substitutions:
+    - "czosnek w marynacie -> olej czosnkowy"
+    - "cebula -> zielona część dymki"
+    - "miód -> syrop klonowy"
 ---
 
 Karkówka z grilla to prawdziwy klasyk polskich grillowań. Ten przepis przedstawia dwie różne marynaty oraz eksperyment z czasem marynowania, który pokazuje, że nie zawsze trzeba marynować mięso przez całą noc - **3 godziny również wystarczą** do uzyskania soczystego i miękkiego mięsa.

--- a/content/kurczak curry.md
+++ b/content/kurczak curry.md
@@ -16,7 +16,7 @@ protein: 11
 fat: 3.9
 carbohydrate: 14.6
 link: https://www.youtube.com/watch?v=gtkbJZfsios
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Porcja ~300 g; brokuły do 75 g/porcję; mleczko kokosowe ≤ 60 ml/porcję"

--- a/content/kurczak curry.md
+++ b/content/kurczak curry.md
@@ -1,21 +1,30 @@
 ---
-draft: false  
-title: "Kurczak w Sosie Curry z Ryżem i Brokułami na Parze"  
-author: "Policzone Szamy"  
-recipe_image: images/recipe-headers/kurczak_curry_ryz_brokuły.jpg  
-date: 2025-07-06T16:55:00-00:00  
-categories: ["obiady"]  
-tags: ["lunchbox"]  
-tagline: "Aromatyczny kurczak w sosie curry z ryżem i świeżymi brokułami na parze."  
-servings: 4  
-prep_time: 20  
-cook: true  
-cook_time: 40  
+draft: false
+title: "Kurczak w Sosie Curry z Ryżem i Brokułami na Parze"
+author: "Policzone Szamy"
+recipe_image: images/recipe-headers/kurczak_curry_ryz_brokuły.jpg
+date: 2025-07-06T16:55:00-00:00
+categories: ["obiady"]
+tags: ["lunchbox"]
+tagline: "Aromatyczny kurczak w sosie curry z ryżem i świeżymi brokułami na parze."
+servings: 4
+prep_time: 20
+cook: true
+cook_time: 40
 calories: 140
 protein: 11
 fat: 3.9
 carbohydrate: 14.6
-link: https://www.youtube.com/watch?v=gtkbJZfsios  
+link: https://www.youtube.com/watch?v=gtkbJZfsios
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Porcja ~300 g; brokuły do 75 g/porcję; mleczko kokosowe ≤ 60 ml/porcję"
+  notes: "Użyj pasty curry bez cebuli i czosnku; unikaj czosnku w całości. Możesz wykorzystać olej czosnkowy."
+  substitutions:
+    - "czosnek -> olej czosnkowy"
+    - "cebula -> zielona część dymki"
+    - "mleczko kokosowe -> ≤ 60 ml + bulion dla objętości"
 ---
 
 ## Składniki

--- a/content/kurczak curry.md
+++ b/content/kurczak curry.md
@@ -19,12 +19,12 @@ link: https://www.youtube.com/watch?v=gtkbJZfsios
 
 fodmap:
   status: "depends"
-  serving_ok: "Porcja ~300 g; brokuły do 75 g/porcję; mleczko kokosowe ≤ 60 ml/porcję"
-  notes: "Użyj pasty curry bez cebuli i czosnku; unikaj czosnku w całości. Możesz wykorzystać olej czosnkowy."
+  serving_ok: "OK po modyfikacjach: bez cebuli/czosnku; brokuły (tylko różyczki) ~60–75 g/porcję; mleczko kokosowe ≤ 60 ml/porcję"
+  notes: "Wybierz pastę curry bez cebuli/czosnku (częste w składzie). Czosnek/cebula to źródło fruktanów – zamień na olej czosnkowy i zielone części dymki. Kokos: ogranicz porcję mleczka, resztę objętości dolej bulionem."
   substitutions:
-    - "czosnek -> olej czosnkowy"
-    - "cebula -> zielona część dymki"
-    - "mleczko kokosowe -> ≤ 60 ml + bulion dla objętości"
+    - "czosnek -> olej czosnkowy (bez cząstek)"
+    - "cebula -> zielona część dymki/szczypior"
+    - "mleczko kokosowe -> ≤ 60 ml + bulion"
 ---
 
 ## Składniki

--- a/content/kurczak w sosie serowym.md
+++ b/content/kurczak w sosie serowym.md
@@ -15,7 +15,13 @@ calories: 164
 protein: 13
 fat: 6
 carbohydrate: 14 
-link: https://www.youtube.com/watch?v=AIlwvEvCONM  
+link: https://www.youtube.com/watch?v=AIlwvEvCONM
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "Bez ograniczeń (sprawdź skład warzyw mrożonych)"
+  notes: "Kurczak, ryż basmati i większość warzyw są bezpieczne."
+  substitutions: []
 ---
 
 ## Składniki

--- a/content/kurczak w sosie serowym.md
+++ b/content/kurczak w sosie serowym.md
@@ -18,10 +18,13 @@ carbohydrate: 14
 link: https://www.youtube.com/watch?v=AIlwvEvCONM
 
 fodmap:
-  status: "yes"
-  serving_ok: "Bez ograniczeń (sprawdź skład warzyw mrożonych)"
-  notes: "Kurczak, ryż basmati i większość warzyw są bezpieczne."
-  substitutions: []
+  status: "depends"
+  serving_ok: "OK po modyfikacjach: bez czosnku; mleko bez laktozy; zagęszczenie skrobią zamiast mąki pszennej"
+  notes: "Czosnek (fruktany) i mąka pszenna podnoszą FODMAP. Ser cheddar bywa niskolaktozowy, ale bazowe mleko powinno być bez laktozy."
+  substitutions:
+    - "czosnek -> olej czosnkowy (bez cząstek)"
+    - "mleko 1,5% -> mleko bez laktozy"
+    - "mąka pszenna -> skrobia kukurydziana/ryżowa"
 ---
 
 ## Składniki

--- a/content/kurczak w sosie serowym.md
+++ b/content/kurczak w sosie serowym.md
@@ -16,7 +16,7 @@ protein: 13
 fat: 6
 carbohydrate: 14 
 link: https://www.youtube.com/watch?v=AIlwvEvCONM
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "Bez ograniczeń (sprawdź skład warzyw mrożonych)"

--- a/content/pasta_jajeczna_suszone_pomidory.md
+++ b/content/pasta_jajeczna_suszone_pomidory.md
@@ -16,7 +16,7 @@ calories: 172
 protein: 13
 fat: 12
 carbohydrate: 3
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "OK w tej porcji"

--- a/content/pasta_jajeczna_suszone_pomidory.md
+++ b/content/pasta_jajeczna_suszone_pomidory.md
@@ -18,10 +18,12 @@ fat: 12
 carbohydrate: 3
 
 fodmap:
-  status: "yes"
-  serving_ok: "OK w tej porcji"
-  notes: "Jajka, tuńczyk, suszone pomidory są bezpieczne"
-  substitutions: []
+  status: "depends"
+  serving_ok: "OK po modyfikacjach: suszone pomidory ≤ 8–12 g/os.; jogurt bez laktozy"
+  notes: "Suszone pomidory powyżej małej porcji mogą zwiększać ładunek FODMAP – ogranicz do ~1–2 kawałków na osobę. Nabiał wybieraj bez laktozy."
+  substitutions:
+    - "jogurt naturalny -> jogurt/skyr bez laktozy"
+    - "za dużo suszonych pomidorów -> ogranicz do 8–12 g/os. lub użyj świeżych w małej ilości"
 link: ""
 ---
 

--- a/content/pasta_jajeczna_suszone_pomidory.md
+++ b/content/pasta_jajeczna_suszone_pomidory.md
@@ -16,6 +16,12 @@ calories: 172
 protein: 13
 fat: 12
 carbohydrate: 3
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "OK w tej porcji"
+  notes: "Jajka, tuńczyk, suszone pomidory są bezpieczne"
+  substitutions: []
 link: ""
 ---
 

--- a/content/pasta_z_kurczaka.md
+++ b/content/pasta_z_kurczaka.md
@@ -16,12 +16,13 @@ calories: 229
 protein: 16.6
 fat: 9.1
 carbohydrate: 18.9
-
 fodmap:
   status: "yes"
-  serving_ok: "OK w tej porcji"
-  notes: "Kurczak, suszone pomidory, majonez, wafle ryżowe - wszystko bezpieczne"
-  substitutions: []
+  serving_ok: "OK przy porcji 1; ogranicz suszone pomidory do 8–12 g"
+  notes: "Bezpieczne: kurczak, wafle ryżowe, majonez bez dodatków. Suszone pomidory tylko w małej porcji; przyprawy bez cebuli/czosnku."
+  substitutions:
+    - "Jogurt bez laktozy zamiast części majonezu (dla lżejszej wersji)."
+    - "Podawaj z pieczywem bezglutenowym/owsianym lub małą porcją chleba orkiszowego na zakwasie."
 link: ""
 ---
 

--- a/content/pasta_z_kurczaka.md
+++ b/content/pasta_z_kurczaka.md
@@ -16,6 +16,12 @@ calories: 229
 protein: 16.6
 fat: 9.1
 carbohydrate: 18.9
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "OK w tej porcji"
+  notes: "Kurczak, suszone pomidory, majonez, wafle ryżowe - wszystko bezpieczne"
+  substitutions: []
 link: ""
 ---
 

--- a/content/pasta_z_kurczaka.md
+++ b/content/pasta_z_kurczaka.md
@@ -16,7 +16,7 @@ calories: 229
 protein: 16.6
 fat: 9.1
 carbohydrate: 18.9
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "OK w tej porcji"

--- a/content/salatka brokul slonecznik.md
+++ b/content/salatka brokul slonecznik.md
@@ -15,6 +15,12 @@ calories: 175
 protein: 11
 fat: 13
 carbohydrate: 6 
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "OK w tej porcji"
+  notes: "Brokuł, pomidory koktajlowe, feta, słonecznik - wszystko bezpieczne"
+  substitutions: []
 link: ""  
 ---
 

--- a/content/salatka brokul slonecznik.md
+++ b/content/salatka brokul slonecznik.md
@@ -15,7 +15,7 @@ calories: 175
 protein: 11
 fat: 13
 carbohydrate: 6 
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "OK w tej porcji"

--- a/content/salatka brokul slonecznik.md
+++ b/content/salatka brokul slonecznik.md
@@ -17,10 +17,11 @@ fat: 13
 carbohydrate: 6 
 
 fodmap:
-  status: "yes"
-  serving_ok: "OK w tej porcji"
-  notes: "Brokuł, pomidory koktajlowe, feta, słonecznik - wszystko bezpieczne"
-  substitutions: []
+  status: "depends"
+  serving_ok: "OK przy użyciu samych różyczek brokuła (~75–90 g/porcję)"
+  notes: "Różyczki brokuła w umiarkowanej porcji są OK; unikaj łodyg. Feta zwykle OK, pestki słonecznika OK."
+  substitutions:
+    - "Brokuł – tylko różyczki; w razie wątpliwości zmniejsz porcję."
 link: ""  
 ---
 

--- a/content/salatka_big_mac.md
+++ b/content/salatka_big_mac.md
@@ -16,7 +16,7 @@ protein: 9.9
 fat: 18.3
 carbohydrate: 2.1
 link: "https://www.youtube.com/watch?v=5dtlGZke2Zg"
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Czerwona cebula - maksymalnie 2 łyżki na porcję"

--- a/content/salatka_big_mac.md
+++ b/content/salatka_big_mac.md
@@ -19,12 +19,12 @@ link: "https://www.youtube.com/watch?v=5dtlGZke2Zg"
 
 fodmap:
   status: "depends"
-  serving_ok: "Czerwona cebula - maksymalnie 2 łyżki na porcję"
-  notes: "Unikaj czosnku w sosie. Czerwona cebula w małych ilościach jest OK."
+  serving_ok: "OK przy małej ilości cebuli i bez czosnku w sosie"
+  notes: "Czerwona cebula tylko w małych ilościach; czosnek w proszku niewskazany. Sery dojrzewające zwykle OK."
   substitutions:
-    - "czerwona cebula -> zielona część dymki"
-    - "czosnek suszony -> olej czosnkowy lub asant (szczypta)"
-    - "duża ilość cebuli -> więcej szczypiorku"
+    - "Czerwona cebula -> zielona część dymki/szczypiorek."
+    - "Czosnek suszony -> olej czosnkowy lub asafetyda (szczypta)."
+    - "Więcej cebuli -> zamień na szczypiorek."
 ---
 
 ## Składniki

--- a/content/salatka_big_mac.md
+++ b/content/salatka_big_mac.md
@@ -16,6 +16,15 @@ protein: 9.9
 fat: 18.3
 carbohydrate: 2.1
 link: "https://www.youtube.com/watch?v=5dtlGZke2Zg"
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Czerwona cebula - maksymalnie 2 łyżki na porcję"
+  notes: "Unikaj czosnku w sosie. Czerwona cebula w małych ilościach jest OK."
+  substitutions:
+    - "czerwona cebula -> zielona część dymki"
+    - "czosnek suszony -> olej czosnkowy lub asant (szczypta)"
+    - "duża ilość cebuli -> więcej szczypiorku"
 ---
 
 ## Składniki

--- a/content/sos winegret.md
+++ b/content/sos winegret.md
@@ -17,10 +17,12 @@ fat: 44
 carbohydrate: 5 
 
 fodmap:
-  status: "yes"
-  serving_ok: "OK w tej porcji"
-  notes: "Miód, musztarda, oliwa są bezpieczne w małych ilościach"
-  substitutions: []
+    status: "depends"
+    serving_ok: "OK po zamianie miodu"
+    notes: "Miód ma wysoki FODMAP (fruktoza); reszta składników jest zwykle OK."
+    substitutions:
+      - "Miód -> syrop klonowy."
+      - "Musztarda – sprawdź skład (bez cebuli/czosnku)."
 link: ""  
 ---
 

--- a/content/sos winegret.md
+++ b/content/sos winegret.md
@@ -15,7 +15,7 @@ calories: 406
 protein: 0.1
 fat: 44
 carbohydrate: 5 
-diets: ["low-fodmap"]
+
 fodmap:
   status: "yes"
   serving_ok: "OK w tej porcji"

--- a/content/sos winegret.md
+++ b/content/sos winegret.md
@@ -15,6 +15,12 @@ calories: 406
 protein: 0.1
 fat: 44
 carbohydrate: 5 
+diets: ["low-fodmap"]
+fodmap:
+  status: "yes"
+  serving_ok: "OK w tej porcji"
+  notes: "Miód, musztarda, oliwa są bezpieczne w małych ilościach"
+  substitutions: []
 link: ""  
 ---
 

--- a/content/sos_serowy.md
+++ b/content/sos_serowy.md
@@ -18,6 +18,11 @@ carbohydrate: 5
 
 fodmap:
   status: "depends"
+  serving_ok: "OK przy użyciu mleka bez laktozy i ograniczonej porcji"
+  notes: "Cheddar ma niską laktozę; problemem jest mleko i mąka pszenna w zasmażce."
+  substitutions:
+    - "Mleko 1,5% -> mleko bez laktozy."
+    - "Mąka pszenna -> skrobia kukurydziana/ryżowa."
   serving_ok: "Sprawdź mleko - używaj bezlaktozowego"
   notes: "Cheddar OK, mąka pszenna w małej ilości. Problem z laktozą"
   substitutions:

--- a/content/sos_serowy.md
+++ b/content/sos_serowy.md
@@ -15,6 +15,14 @@ calories: 158
 protein: 7
 fat: 12
 carbohydrate: 5
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Sprawdź mleko - używaj bezlaktozowego"
+  notes: "Cheddar OK, mąka pszenna w małej ilości. Problem z laktozą"
+  substitutions:
+    - "mleko zwykłe -> mleko bezlaktozowe"
+    - "mąka pszenna -> mąka ryżowa (zagęszczanie)"
 link: https://www.youtube.com/watch?v=AIlwvEvCONM
 ---
 

--- a/content/sos_serowy.md
+++ b/content/sos_serowy.md
@@ -15,7 +15,7 @@ calories: 158
 protein: 7
 fat: 12
 carbohydrate: 5
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Sprawdź mleko - używaj bezlaktozowego"

--- a/content/tacos.md
+++ b/content/tacos.md
@@ -18,6 +18,12 @@ carbohydrate: 30
 
 fodmap:
   status: "depends"
+  serving_ok: "Nieodpowiednie w obecnej wersji (cebula, czosnek, awokado)"
+  notes: "Tortille pszenne – pszenica (fruktany); cebula/czosnek niewskazane; awokado wysokie FODMAP (sorbitol) w większych porcjach."
+  substitutions:
+    - "Tortilla pszenna -> tortilla kukurydziana (100% kukurydza)."
+    - "Cebula/czosnek -> zielona część dymki + olej czosnkowy."
+    - "Awokado -> mała porcja (≤30 g) lub pominąć."
   serving_ok: "Mała porcja - uważaj na cebulę i pszenną tortillę"
   notes: "Cebula (2 łyżki max), pszenica w tortilli problematyczna"
   substitutions:

--- a/content/tacos.md
+++ b/content/tacos.md
@@ -15,6 +15,15 @@ calories: 575
 protein: 35
 fat: 25
 carbohydrate: 30
+diets: ["low-fodmap"]
+fodmap:
+  status: "depends"
+  serving_ok: "Mała porcja - uważaj na cebulę i pszenną tortillę"
+  notes: "Cebula (2 łyżki max), pszenica w tortilli problematyczna"
+  substitutions:
+    - "tortilla pszenna -> tortilla kukurydziana"
+    - "cebula -> dymka (tylko zielone części)"
+    - "duże porcje cebuli -> posypka szczypiorkiem"
 link: https://www.youtube.com/watch?v=UKEwoHAWCTs
 ---
 

--- a/content/tacos.md
+++ b/content/tacos.md
@@ -15,7 +15,7 @@ calories: 575
 protein: 35
 fat: 25
 carbohydrate: 30
-diets: ["low-fodmap"]
+
 fodmap:
   status: "depends"
   serving_ok: "Mała porcja - uważaj na cebulę i pszenną tortillę"

--- a/hugo.toml
+++ b/hugo.toml
@@ -9,6 +9,7 @@ defaultContentLanguage = "pl"
   categories = "categories"
   subcategories = "subcategories"
   tag = "tags"
+  diet = "diets"
 
 [languages]
   [languages.pl]
@@ -47,6 +48,18 @@ fileName = "/images/icon.png" #your favicon here if you wish to change it.
     pre = "fas fa-list"
     identifier = "categories"
     weight = 2  
+    
+    [[menu.main]]
+    name = "Diety"
+    pre = "fas fa-leaf"
+    identifier = "diety"
+    url = "/diets/"
+    weight = 3
+  [[menu.main]]
+    name = "Low FODMAP"
+    parent = "diety"
+    url = "/diets/low-fodmap/"
+    weight = 31
     
     [[menu.main]]
     name = "Śniadania"
@@ -88,7 +101,7 @@ fileName = "/images/icon.png" #your favicon here if you wish to change it.
     name = "Tagi" # change to w/e you want, tags or categories works best
     pre = "fas fa-tags" #icon, change if you would prefer a different icon
     url = "/tags/"
-    weight = 3
+  weight = 4
 
 # Print output just creates a special route for a print view
 [outputs]

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -37,3 +37,19 @@
   translation: "minut"
 - id: kcal
   translation: "kcal"
+
+# FODMAP
+- id: fodmap.title
+  translation: "Low FODMAP"
+- id: fodmap.status.yes
+  translation: "Tak"
+- id: fodmap.status.no
+  translation: "Nie"
+- id: fodmap.status.depends
+  translation: "Zależy"
+- id: fodmap.serving_ok
+  translation: "Bezpieczna porcja"
+- id: fodmap.notes
+  translation: "Uwaga"
+- id: fodmap.substitutions
+  translation: "Zamienniki"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,6 +12,7 @@
                     <div class="recipe-hero__gradient" aria-hidden="true"></div>
                     <div class="recipe-hero__title">
                         <h1 class="title is-bold has-text-white">{{ .Title }}</h1>
+                        <div style="margin-top:.5rem;">{{ partial "fodmap-badge.html" . }}</div>
                     </div>
                     {{ if .Params.link }}
                     <div id="youtubeButton" class="is-rounded media-badge media-badge--left">
@@ -42,6 +43,8 @@
             <div class="content">
                 {{ .Content }}
             </div>
+            {{/* FODMAP panel placed after content (below nutrition tables which precede .Content) */}}
+            {{ partial "fodmap-panel.html" . }}
         </div>
     </div>
 </div>

--- a/layouts/diet/list.html
+++ b/layouts/diet/list.html
@@ -1,12 +1,68 @@
 {{ define "main" }}
+<!-- DEBUG: Używamy szablonu diet/list.html -->
 <div class="section">
-  <h1 class="title"><i class="fas fa-leaf" aria-hidden="true"></i> {{ .Title }}</h1>
-  <div class="columns is-multiline">
-    {{ range .Pages }}
-      <div class="column is-one-quarter">
-        {{ partial "summary.html" . }}
-      </div>
-    {{ end }}
-  </div>
+    <div class="container">
+        <!-- DEBUG: Title = {{ .Title }}, Type = {{ .Type }}, Kind = {{ .Kind }} -->
+        {{ if eq .Title "low-fodmap" }}
+        {{/* Specjalna strona dla Low FODMAP - pokazuje tylko przepisy z fodmap.status = "yes" */}}
+        <h1 class="title"><i class="fas fa-leaf has-text-success"></i> Low FODMAP - Bezpieczne Przepisy</h1>
+        <p class="subtitle">
+            Przepisy oznaczone jako w pełni bezpieczne dla diety Low FODMAP
+        </p>
+        
+        <div class="notification is-info is-light mb-5">
+            <p><strong>Co to oznacza?</strong> Te przepisy zawierają tylko składniki o niskiej zawartości FODMAP i można je spożywać bez ograniczeń w normalnych porcjach.</p>
+        </div>
+        
+        {{/* Filtruj wszystkie strony w site - tylko te z fodmap.status = "yes" */}}
+        {{ $safePages := where site.RegularPages ".Params.fodmap.status" "yes" }}
+        
+        <p class="has-text-grey mb-4">
+            <i class="fas fa-check-circle has-text-success"></i> 
+            {{ len $safePages }} {{ if eq (len $safePages) 1 }}bezpieczny przepis{{ else }}bezpiecznych przepisów{{ end }}
+        </p>
+        
+        <div class="columns is-multiline">
+            {{ range $safePages.ByPublishDate.Reverse }}
+            <div class="column is-one-quarter">
+                {{ partial "summary.html" . }}
+            </div>
+            {{ end }}
+        </div>
+        
+        {{/* Dodaj sekcję z przepisami "depends" */}}
+        {{ $dependsPages := where site.RegularPages ".Params.fodmap.status" "depends" }}
+        {{ if gt (len $dependsPages) 0 }}
+        <hr class="my-6">
+        <h2 class="title is-4"><i class="fas fa-exclamation-triangle has-text-warning"></i> Przepisy z ograniczeniami</h2>
+        <p class="subtitle">
+            Przepisy, które można dostosować do diety Low FODMAP
+        </p>
+        
+        <div class="notification is-warning is-light">
+            <p><strong>Uwaga:</strong> Te przepisy wymagają modyfikacji składników lub ograniczeń porcji. Każdy przepis zawiera szczegółowe instrukcje jak je dostosować do diety Low FODMAP.</p>
+        </div>
+        
+        <div class="columns is-multiline">
+            {{ range $dependsPages.ByPublishDate.Reverse }}
+            <div class="column is-one-quarter">
+                {{ partial "summary.html" . }}
+            </div>
+            {{ end }}
+        </div>
+        {{ end }}
+        
+        {{ else }}
+        {{/* Domyślny szablon dla innych diet */}}
+        <h1 class="title"><i class="fas fa-leaf" aria-hidden="true"></i> {{ .Title }}</h1>
+        <div class="columns is-multiline">
+            {{ range .Pages }}
+            <div class="column is-one-quarter">
+                {{ partial "summary.html" . }}
+            </div>
+            {{ end }}
+        </div>
+        {{ end }}
+    </div>
 </div>
 {{ end }}

--- a/layouts/diet/list.html
+++ b/layouts/diet/list.html
@@ -1,0 +1,12 @@
+{{ define "main" }}
+<div class="section">
+  <h1 class="title"><i class="fas fa-leaf" aria-hidden="true"></i> {{ .Title }}</h1>
+  <div class="columns is-multiline">
+    {{ range .Pages }}
+      <div class="column is-one-quarter">
+        {{ partial "summary.html" . }}
+      </div>
+    {{ end }}
+  </div>
+</div>
+{{ end }}

--- a/layouts/diet/terms.html
+++ b/layouts/diet/terms.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+<div class="section">
+  <h1 class="title">Diety</h1>
+  <div class="columns is-multiline">
+    {{ range .Pages.ByTitle }}
+    <div class="column is-one-quarter">
+      <div class="card">
+        <header class="card-header">
+          <p class="card-header-title">
+            <a class="title" href="{{ .RelPermalink }}">{{ .Title }}</a>
+            <i class="fas fa-leaf pl-3 pb-3"></i>
+          </p>
+        </header>
+        <div class="card-content">
+          {{ $cat := lower .Title }}
+          {{ with .Site.GetPage (printf "diet/%s" $cat) }}
+            {{ range first 5 .Pages }}
+              <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+            {{ end }}
+          {{ end }}
+        </div>
+      </div>
+    </div>
+    {{ end }}
+  </div>
+ </div>
+{{ end }}

--- a/layouts/partials/fodmap-badge.html
+++ b/layouts/partials/fodmap-badge.html
@@ -1,0 +1,14 @@
+{{/* FODMAP badge next to titles or anywhere compact */}}
+{{ $isLowFodmap := in (default (slice) .Params.diets) "low-fodmap" }}
+{{ $status := (cond (and .Params.fodmap .Params.fodmap.status) .Params.fodmap.status "") }}
+{{ if or $isLowFodmap $status }}
+  {{ $label := "Low FODMAP" }}
+  {{ $mod := "" }}
+  {{ if eq $status "yes" }}{{ $mod = " fodmap--yes" }}{{ end }}
+  {{ if eq $status "depends" }}{{ $mod = " fodmap--depends" }}{{ end }}
+  {{ if eq $status "no" }}{{ $mod = " fodmap--no" }}{{ end }}
+  <span class="fodmap-badge{{ $mod }}">
+    <i class="fas fa-leaf" aria-hidden="true"></i>
+    {{ $label }}{{ if $status }}: {{ i18n (print "fodmap.status." $status) | default (title $status) }}{{ end }}
+  </span>
+{{ end }}

--- a/layouts/partials/fodmap-panel.html
+++ b/layouts/partials/fodmap-panel.html
@@ -1,0 +1,28 @@
+{{/* Detailed FODMAP panel for recipe pages */}}
+{{ with .Params.fodmap }}
+  <div class="fodmap-panel">
+    <div class="fodmap-row" style="justify-content: space-between;">
+      <h3 class="title is-5" style="margin: 0;">
+        <i class="fas fa-seedling" aria-hidden="true"></i>
+        {{ i18n "fodmap.title" | default "Low FODMAP" }}
+      </h3>
+      {{ partial "fodmap-badge.html" $ }}
+    </div>
+    <div class="content" style="margin-top:.5rem;">
+      {{ if .serving_ok }}
+      <p><strong>{{ i18n "fodmap.serving_ok" | default "Bezpieczna porcja" }}:</strong> {{ .serving_ok }}</p>
+      {{ end }}
+      {{ if .notes }}
+      <p><strong>{{ i18n "fodmap.notes" | default "Uwaga" }}:</strong> {{ .notes }}</p>
+      {{ end }}
+      {{ with .substitutions }}
+      <p><strong>{{ i18n "fodmap.substitutions" | default "Zamienniki" }}:</strong></p>
+      <ul>
+        {{ range . }}
+          <li>{{ . }}</li>
+        {{ end }}
+      </ul>
+      {{ end }}
+    </div>
+  </div>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -19,4 +19,25 @@
     {{ $title := print .Site.Title " | " .Title }}
     {{ if .IsHome }}{{ $title = .Site.Title }}{{ end }}
     <title>{{ $title }}</title>
+            {{ if in (default (slice) .Params.diets) "low-fodmap" }}
+                {{ $kw := (slice "low fodmap") }}
+                {{ with .Params.tags }}{{ $kw = $kw | append . }}{{ end }}
+                <meta name="keywords" content="{{ delimit $kw ", " }}">
+            {{/* Basic JSON-LD augmentation: add additionalProperty for lowFODMAP if recipe schema exists elsewhere; otherwise embed minimal */}}
+            <script type="application/ld+json">
+            {{ $status := (cond (and .Params.fodmap .Params.fodmap.status) .Params.fodmap.status "") }}
+            {{ $desc := (cond (and .Params.fodmap .Params.fodmap.notes) .Params.fodmap.notes "") }}
+            {
+                "@context": "https://schema.org",
+                "@type": "Recipe",
+                "name": {{ printf "%q" .Title }},
+                "additionalProperty": [{
+                    "@type": "PropertyValue",
+                    "name": "lowFODMAP",
+                    "value": {{ printf "%q" $status }},
+                    "description": {{ printf "%q" $desc }}
+                }]
+            }
+            </script>
+        {{ end }}
 </head>

--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -15,9 +15,20 @@
             </figure>
         </div>
           <div class="card-content" style="flex-grow: 1; display: flex; flex-direction: column;">
-            <div class="media-content" style="height: 4em; display: flex; align-items: center;">
-                <p class="title is-4 has-text-centered" style="width: 100%; margin: 0; display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;">{{ $.Title }}</p>
-            </div>
+                        <div class="media-content" style="height: 4.5em; display: flex; align-items: center; justify-content: space-between; gap:.5rem;">
+                                <p class="title is-4 has-text-centered" style="flex:1; margin: 0; display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;">{{ $.Title }}</p>
+                                {{ $isLow := in (default (slice) $.Params.diets) "low-fodmap" }}
+                                {{ $status := (cond (and $.Params.fodmap $.Params.fodmap.status) $.Params.fodmap.status "") }}
+                                {{ if or $isLow $status }}
+                                    {{ $mod := "" }}
+                                    {{ if eq $status "yes" }}{{ $mod = " fodmap--yes" }}{{ end }}
+                                    {{ if eq $status "depends" }}{{ $mod = " fodmap--depends" }}{{ end }}
+                                    {{ if eq $status "no" }}{{ $mod = " fodmap--no" }}{{ end }}
+                                    <span class="fodmap-badge{{ $mod }}" title="Low FODMAP">
+                                        <i class="fas fa-leaf" aria-hidden="true"></i>
+                                    </span>
+                                {{ end }}
+                        </div>
         <div class="content" style="flex-grow: 1; display: flex; flex-direction: column;">           
             <div style="height: 3em; display: flex; justify-content: center; align-items: center; margin-top: .2em;">
                 <div style="display: flex; flex-wrap: wrap; gap: 1em; font-size: 0.8em; align-items: center; justify-content: center;">

--- a/layouts/taxonomy/list.html
+++ b/layouts/taxonomy/list.html
@@ -1,6 +1,175 @@
 {{ define "main" }}
+<!-- DEBUG: Używamy szablonu taxonomy/list.html -->
+<!-- DEBUG: Title = {{ .Title }}, Type = {{ .Type }}, Kind = {{ .Kind }} -->
 <div class="section">
     <div class="container">
+        {{ if eq .Title "low-fodmap" }}
+        {{/* Specjalna strona dla Low FODMAP - pokazuje tylko przepisy z fodmap.status = "yes" */}}
+        <h1 class="title"><i class="fas fa-leaf has-text-success"></i> Low FODMAP - Bezpieczne Przepisy</h1>
+        <p class="subtitle">
+            Przepisy oznaczone jako w pełni bezpieczne dla diety Low FODMAP
+        </p>
+        
+        <div class="notification is-info is-light mb-5">
+            <p><strong>Co to oznacza?</strong> Te przepisy zawierają tylko składniki o niskiej zawartości FODMAP i można je spożywać bez ograniczeń w normalnych porcjach.</p>
+        </div>
+        
+        {{/* Filtruj wszystkie strony w site - tylko te z fodmap.status = "yes" */}}
+        {{ $safePages := where site.RegularPages ".Params.fodmap.status" "yes" }}
+        
+        <p class="has-text-grey mb-4">
+            <i class="fas fa-check-circle has-text-success"></i> 
+            {{ len $safePages }} {{ if eq (len $safePages) 1 }}bezpieczny przepis{{ else }}bezpiecznych przepisów{{ end }}
+        </p>
+        
+        <div class="columns is-multiline">
+            {{ range $safePages.ByPublishDate.Reverse }}
+            <div class="column is-one-third">
+                <div class="card">
+                    <div class="card-image">
+                        <figure class="image is-4by3">
+                            {{- $image_url := partial "asset-url.html" "/images/defaultImage.png" -}}
+                            {{- if and .Params.recipe_image (fileExists (printf "static/%s" .Params.recipe_image)) -}}
+                                {{- $image_url = partial "asset-url.html" (printf "/%s" .Params.recipe_image) -}}
+                            {{- end -}}
+                            <img src="{{ $image_url }}" alt="{{ .Title }}">
+                        </figure>
+                    </div>
+                    <div class="card-content">
+                        <div class="media">
+                            <div class="media-content">
+                                <p class="title is-5">
+                                    <a href="{{ .Permalink }}">{{ .Title }}</a>
+                                    {{/* Dodajemy zielony znaczek dla bezpiecznych przepisów */}}
+                                    {{ partial "fodmap-badge.html" . }}
+                                </p>
+                                {{ if .Params.tagline }}
+                                <p class="subtitle is-6">{{ .Params.tagline }}</p>
+                                {{ end }}
+                            </div>
+                        </div>
+                        
+                        <div class="content">
+                            {{ if .Params.servings }}
+                            <span class="tag is-light">
+                                <i class="fas fa-users pr-1"></i>{{ .Params.servings }} porcji
+                            </span>
+                            {{ end }}
+                            
+                            {{ if .Params.prep_time }}
+                            <span class="tag is-light">
+                                <i class="fas fa-clock pr-1"></i>{{ .Params.prep_time }} min
+                            </span>
+                            {{ end }}
+                            
+                            {{ if .Params.calories }}
+                            <span class="tag is-light">
+                                <i class="fas fa-fire pr-1"></i>{{ .Params.calories }} kcal
+                            </span>
+                            {{ end }}
+                            
+                            {{/* Pokazujemy informacje FODMAP */}}
+                            {{ if .Params.fodmap }}
+                            <br>
+                            <span class="tag is-success is-light">
+                                <i class="fas fa-check pr-1"></i>{{ .Params.fodmap.serving_ok }}
+                            </span>
+                            {{ end }}
+                            
+                            <br><br>
+                            {{ if .Params.tags }}
+                            {{ range .Params.tags }}
+                            <span class="tag is-primary is-light">{{ . }}</span>
+                            {{ end }}
+                            {{ end }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {{ end }}
+        </div>
+        
+        {{/* Dodaj sekcję z przepisami "depends" */}}
+        {{ $dependsPages := where site.RegularPages ".Params.fodmap.status" "depends" }}
+        {{ if gt (len $dependsPages) 0 }}
+        <hr class="my-6">
+        <h2 class="title is-4"><i class="fas fa-exclamation-triangle has-text-warning"></i> Przepisy z ograniczeniami</h2>
+        <p class="subtitle">
+            Przepisy, które można dostosować do diety Low FODMAP
+        </p>
+        
+        <div class="notification is-warning is-light">
+            <p><strong>Uwaga:</strong> Te przepisy wymagają modyfikacji składników lub ograniczeń porcji. Każdy przepis zawiera szczegółowe instrukcje jak je dostosować do diety Low FODMAP.</p>
+        </div>
+        
+        <div class="columns is-multiline">
+            {{ range $dependsPages.ByPublishDate.Reverse }}
+            <div class="column is-one-third">
+                <div class="card">
+                    <div class="card-image">
+                        <figure class="image is-4by3">
+                            {{- $image_url := partial "asset-url.html" "/images/defaultImage.png" -}}
+                            {{- if and .Params.recipe_image (fileExists (printf "static/%s" .Params.recipe_image)) -}}
+                                {{- $image_url = partial "asset-url.html" (printf "/%s" .Params.recipe_image) -}}
+                            {{- end -}}
+                            <img src="{{ $image_url }}" alt="{{ .Title }}">
+                        </figure>
+                    </div>
+                    <div class="card-content">
+                        <div class="media">
+                            <div class="media-content">
+                                <p class="title is-5">
+                                    <a href="{{ .Permalink }}">{{ .Title }}</a>
+                                    {{ partial "fodmap-badge.html" . }}
+                                </p>
+                                {{ if .Params.tagline }}
+                                <p class="subtitle is-6">{{ .Params.tagline }}</p>
+                                {{ end }}
+                            </div>
+                        </div>
+                        
+                        <div class="content">
+                            {{ if .Params.servings }}
+                            <span class="tag is-light">
+                                <i class="fas fa-users pr-1"></i>{{ .Params.servings }} porcji
+                            </span>
+                            {{ end }}
+                            
+                            {{ if .Params.prep_time }}
+                            <span class="tag is-light">
+                                <i class="fas fa-clock pr-1"></i>{{ .Params.prep_time }} min
+                            </span>
+                            {{ end }}
+                            
+                            {{ if .Params.calories }}
+                            <span class="tag is-light">
+                                <i class="fas fa-fire pr-1"></i>{{ .Params.calories }} kcal
+                            </span>
+                            {{ end }}
+                            
+                            {{/* Pokazujemy informacje FODMAP */}}
+                            {{ if .Params.fodmap }}
+                            <br>
+                            <span class="tag is-success is-light">
+                                <i class="fas fa-check pr-1"></i>{{ .Params.fodmap.serving_ok }}
+                            </span>
+                            {{ end }}
+                            
+                            <br><br>
+                            {{ if .Params.tags }}
+                            {{ range .Params.tags }}
+                            <span class="tag is-primary is-light">{{ . }}</span>
+                            {{ end }}
+                            {{ end }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {{ end }}
+        </div>
+        {{ end }}
+        
+        {{ else }}
         <h1 class="title">{{ .Title }}</h1>
         <p class="subtitle">{{ len .Pages }} {{ if eq (len .Pages) 1 }}przepis{{ else }}przepisów{{ end }} w kategorii "{{ .Title }}"</p>
         
@@ -60,6 +229,7 @@
             </div>
             {{ end }}
         </div>
+        {{ end }}
     </div>
 </div>
 {{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -300,3 +300,32 @@ body, button, input, optgroup, select, textarea {
     .recipe-hero { max-width: 100%; }
     .media-badge { bottom: 8px; }
 }
+
+/* ===== FODMAP BADGE & PANEL ===== */
+.fodmap-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: .35em;
+    padding: .25em .6em;
+    border-radius: 999px;
+    font-size: .85rem;
+    font-weight: 700;
+    border: 1px solid #d1d5db;
+    color: #374151;
+    background: #e5e7eb;
+}
+.fodmap-badge i { font-size: .95em; }
+.fodmap-badge.fodmap--yes { color: #15803d; background: #22c55e20; border-color: #22c55e66; }
+.fodmap-badge.fodmap--depends { color: #92400e; background: #f59e0b20; border-color: #f59e0b66; }
+.fodmap-badge.fodmap--no { color: #991b1b; background: #ef444420; border-color: #ef444466; }
+
+.fodmap-panel {
+    margin-top: 1.25rem;
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    background: #fafafa;
+}
+.fodmap-panel h3 { margin-top: 0; margin-bottom: .5rem; }
+.fodmap-panel ul { margin: .5rem 0 0 1.25rem; }
+.fodmap-row { display:flex; gap:.5rem; align-items:center; flex-wrap:wrap; }


### PR DESCRIPTION
### Config and taxonomy

- hugo.toml
  - Added diet taxonomy: diet = "diets".
  - Menu: new “Diety” section and submenu entry to “Low FODMAP” (/diets/low-fodmap/).
  - Minor SEO augmentation in head partial (see below).

- New content sections
  - Added _index.md
  - Added _index.md

- i18n
  - i18n/pl.yaml: New translation keys for FODMAP panel:
    - fodmap.title/status.{yes,no,depends}/serving_ok/notes/substitutions

### Templates and UI

- New partials
  - fodmap-badge.html
    - Compact badge with color modifiers for yes/depends/no, shown near titles and cards.
  - fodmap-panel.html
    - Detailed panel rendering serving_ok, notes, substitutions (bullet list).

- Integrated in pages
  - single.html
    - Badge in the hero/title area; full panel rendered below recipe content.
  - summary.html
    - Card list shows a small FODMAP badge on each card when present.

- Diet listing pages
  - New: list.html and terms.html
  - Updated: list.html
    - Special handling for “low-fodmap”: top section lists recipes with status=yes; a second section lists status=depends with explanatory notices.

- Head/SEO
  - head.html
    - If a recipe includes “low-fodmap” (diet or status), adds meta keywords and a JSON‑LD snippet with additionalProperty lowFODMAP: status and description.

- CSS
  - custom.css
    - Styles for .fodmap-badge (color-coded) and .fodmap-panel.
    - General modern card/button rounding and minor layout polish.

### Content (recipes) updated with FODMAP metadata

- Updated recipes: 48 Markdown files under content/*.md now include a YAML block:
  - fodmap:
    - status: "yes" | "depends" | "no"
    - serving_ok: short condition/portion guidance
    - notes: brief reasons/risks
    - substitutions: list of concrete swaps

- Status distribution (current branch):
  - yes: 3 (e.g., Jajecznica.md, Sos Majonezowy Z Limonką.md, pasta_z_kurczaka.md)
  - depends: 35 (various mains, breakfasts, sauces—portion caps and swaps)
  - no: 10 (e.g., Chilli con carne.md, Naleśniki.md, Gulasz Z Łopatki Wieprzowej.md, fasola po bretonsku.md)

- Representative examples
  - “depends” examples emphasize:
    - Portion caps (avocado ≤ 30 g, sun‑dried tomatoes ~8–12 g/person, broccoli florets ~60–75 g, coconut milk ≤ 60 ml, cherry tomatoes ≤ 5, small/less‑ripe banana).
    - Garlic/onion swaps (green tops of scallions, garlic‑infused oil), LF dairy, GF bases, honey→maple.
  - “no” examples call out beans/pszenica/cebula/czosnek/laktoza content that can’t be reasonably adapted.

### Other changes

- .github/chatmodes/recipe_maker.chatmode.md: minor adjustments (non‑functional).
- Various small template polish for list cards and layout consistency.

## Notable anomaly to fix

- Duplicate keys in a single FODMAP block:
  - content/fasola po bretonsku.md contains duplicate serving_ok, notes, and substitutions entries within one fodmap: block. Recommend keeping one set:
    - status: "no"
    - serving_ok: "Unikaj na diecie Low FODMAP"
    - notes: concise single note
    - substitutions: a single, coherent list

If you want, I can clean that duplication in a follow‑up commit.

## Summary

- Low FODMAP support was added end‑to‑end: taxonomy, menus, i18n, SEO hints, UI badge/panel, and a dedicated diet listing view.
- 48 recipes gained standardized FODMAP metadata. Current distribution: 3 yes, 35 depends, 10 no.
- UI styling and cards got light improvements.
- One file shows duplicated FODMAP keys; everything else looks consistent.